### PR TITLE
default message for errors bugfix

### DIFF
--- a/pubs/repo.py
+++ b/pubs/repo.py
@@ -21,7 +21,7 @@ class CiteKeyError(Exception):
         self.citekey = citekey
 
     def __str__(self):
-        return self.message or self.default_msg.format(self.citekey)
+        return self.message or self.default_message.format(self.citekey)
 
 
 class CiteKeyCollision(CiteKeyError):


### PR DESCRIPTION
There is a bug in `pubs/repo.py`, which references the `default_msg` of the error classes instead of their `default_message`