### PR TITLE
use vim as an editor command by default

### DIFF
--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -20,7 +20,7 @@ open_cmd = string(default=None)
 # if using a graphical editor, use the --wait or --block option, i.e.:
 # "atom --wait"
 # "kate --block"
-edit_cmd = string(default='')
+edit_cmd = string(default='vim')
 
 # If true debug mode is on which means exceptions are not catched and
 # the full python stack is printed.


### PR DESCRIPTION
This is a potential fix for #57, which arises from a call to the default editor and then a temporary file. As the default editor is the empty string, this results in `subprocess.call(['/tmp/tempfile'])`, which errors `error: [Errno 13] Permission denied` as the file is not executable.

Using vim as the default is not a perfect solution, but at least the error message will now be more clear if the user does not have vim installed: `error: [Errno 2] No such file or directory: 'vim'`