### PR TITLE
link by default and allow overwriting when importing a bibtex file

### DIFF
--- a/pubs/commands/import_cmd.py
+++ b/pubs/commands/import_cmd.py
@@ -20,6 +20,8 @@ def parser(subparsers):
             help="don't copy document files, just create a link.")
     parser.add_argument('keys', nargs='*',
             help="one or several keys to import from the file")
+    parser.add_argument('-O', '--overwrite', default=True,
+            help="Overwrite keys already in the database")
     return parser
 
 
@@ -78,13 +80,12 @@ def command(conf, args):
         if isinstance(p, Exception):
             ui.error(u'Could not load entry for citekey {}.'.format(k))
         else:
-            rp.push_paper(p)
+            rp.push_paper(p, overwrite=args.overwrite)
             ui.info(u'{} imported.'.format(color.dye_out(p.citekey, 'citekey')))
             docfile = bibstruct.extract_docfile(p.bibdata)
             if docfile is None:
                 ui.warning("No file for {}.".format(p.citekey))
             else:
-                rp.push_doc(p.citekey, docfile, copy=copy)
-                #FIXME should move the file if configured to do so.
+                rp.push_doc(p.citekey, docfile)
 
     rp.close()

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -11,7 +11,7 @@ docsdir = string(default="docsdir://")
 
 # Specify if a document should be copied or moved in the docdir, or only
 # linked when adding a publication.
-doc_add = option('copy', 'move', 'link', default='copy')
+doc_add = option('copy', 'move', 'link', default='link')
 
 # the command to use when opening document files
 open_cmd = string(default=None)

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -11,7 +11,7 @@ docsdir = string(default="docsdir://")
 
 # Specify if a document should be copied or moved in the docdir, or only
 # linked when adding a publication.
-doc_add = option('copy', 'move', 'link', default='move')
+doc_add = option('copy', 'move', 'link', default='copy')
 
 # the command to use when opening document files
 open_cmd = string(default=None)


### PR DESCRIPTION
I personally prefer overwriting existing entries when importing a bibtex file, so I created a flag `-O` or `--overwrite` to allow that and set it to `True` by default.

In doing so, I also pass the copy config value to `push_doc`. If `overwrite` is `True` and the `copy` configuration is `copy` or `move`, the import will fail as the file already exists. For this reason, and because I think `link` is a more reasonable default (doesn't bloat a `~/.` directory and doesn't move pdfs that are maybe being used by other programs, like Mendeley), I also changed the default to `link`.