### PR TITLE
overwrite argument on import

### DIFF
--- a/pubs/commands/import_cmd.py
+++ b/pubs/commands/import_cmd.py
@@ -20,6 +20,8 @@ def parser(subparsers):
             help="don't copy document files, just create a link.")
     parser.add_argument('keys', nargs='*',
             help="one or several keys to import from the file")
+    parser.add_argument('-O', '--overwrite', default=False,
+            help="Overwrite keys already in the database")
     return parser
 
 
@@ -78,7 +80,7 @@ def command(conf, args):
         if isinstance(p, Exception):
             ui.error(u'Could not load entry for citekey {}.'.format(k))
         else:
-            rp.push_paper(p)
+            rp.push_paper(p, overwrite=args.overwrite)
             ui.info(u'{} imported.'.format(color.dye_out(p.citekey, 'citekey')))
             docfile = bibstruct.extract_docfile(p.bibdata)
             if docfile is None:


### PR DESCRIPTION
This allows for overwriting existing entries based on argument input for the `import` command. Note that this will currently fail when overwriting an entry with a `file` field and existing doc, due to line `89:                rp.push_doc(p.citekey, docfile, copy=copy)`. See #64 for more discussion.