### PR TITLE
Keylist

### DIFF
--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -33,7 +33,7 @@ def command(conf, args):
         bib[p.citekey] = p.bibdata
 
     exporter = endecoder.EnDecoder()
-    bibdata_raw = exporter.encode_bibdata(bib)
+    bibdata_raw = exporter.encode_bibdata(bib, conf['main']['keylist'])
     ui.message(bibdata_raw)
 
     rp.close()

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -28,6 +28,9 @@ edit_cmd = string(default='')
 # the full python stack is printed.
 debug = boolean(default=False)
 
+# BibTeX keys to export
+keylist = string_list(default=[])
+
 [formating]
 
 # Enable bold formatting, if the terminal supports it.

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -29,7 +29,8 @@ edit_cmd = string(default='')
 debug = boolean(default=False)
 
 # BibTeX keys to export
-keylist = string_list(default=[])
+keylist = force_list(default=list())
+
 
 [formating]
 

--- a/pubs/endecoder.py
+++ b/pubs/endecoder.py
@@ -106,7 +106,7 @@ class EnDecoder(object):
                 bibraw += '    {} = {{{}}},\n'.format(
                     key, EnDecoder._encode_field(key, value))
         for key, value in bibentry.items():
-            if key != TYPE_KEY:
+            if key != TYPE_KEY and (not keylist or key in keylist):
                 bibraw += '    {} = {{{}}},\n'.format(
                     key, EnDecoder._encode_field(key, value))
         bibraw += '}\n'

--- a/pubs/endecoder.py
+++ b/pubs/endecoder.py
@@ -76,9 +76,9 @@ class EnDecoder(object):
     def decode_metadata(self, metadata_raw):
         return yaml.safe_load(metadata_raw)
 
-    def encode_bibdata(self, bibdata):
+    def encode_bibdata(self, bibdata, keylist=[]):
         """Encode bibdata """
-        return '\n'.join(self._encode_bibentry(citekey, entry)
+        return '\n'.join(self._encode_bibentry(citekey, entry, keylist)
                          for citekey, entry in bibdata.items())
 
     @staticmethod
@@ -97,11 +97,11 @@ class EnDecoder(object):
             return value
 
     @staticmethod
-    def _encode_bibentry(citekey, bibentry):
+    def _encode_bibentry(citekey, bibentry, keylist):
         bibraw = '@{}{{{},\n'.format(bibentry[TYPE_KEY], citekey)
         bibentry = copy.copy(bibentry)
         for key in bibfield_order:
-            if key in bibentry:
+            if key in bibentry and (not keylist or key in keylist):
                 value = bibentry.pop(key)
                 bibraw += '    {} = {{{}}},\n'.format(
                     key, EnDecoder._encode_field(key, value))


### PR DESCRIPTION
This feature allows the user to configure a list of keys for the exported bib. For example, I dislike having the `abstract` text in my `bib` files, so I've configured my keylist as:
`keylist = author, title, journal, publisher, year, month, number, volume, pages, url`

An empty keylist, the default, maintains current behavior.
Sorry if this is a lot of pull requests ^.^