### PR TITLE
Print help when no subcommand is provided (#99)

### DIFF
--- a/pubs/pubs_cmd.py
+++ b/pubs/pubs_cmd.py
@@ -83,13 +83,17 @@ def execute(raw_args=sys.argv):
 
         # Eventually autocomplete
         autocomplete(parser)
+
         # Parse and run appropriate command
+        # if no command, print help and exit peacefully (as '--help' does)
         args = parser.parse_args(remaining_args)
+
         if not args.command:
             parser.print_help()
-        else:
-            args.prog = "pubs"  # FIXME?
-            args.func(conf, args)
+            sys.exit(0)
+
+        args.prog = "pubs"  # FIXME?
+        args.func(conf, args)
 
     except Exception as e:
         if not uis.get_ui().handle_exception(e):

--- a/pubs/pubs_cmd.py
+++ b/pubs/pubs_cmd.py
@@ -69,7 +69,7 @@ def execute(raw_args=sys.argv):
                                          prog="pubs", add_help=True)
         parser.add_argument('--version', action='version', version=__version__)
         subparsers = parser.add_subparsers(title="valid commands", dest="command")
-        subparsers.required = True
+        #subparsers.required = True
 
         # Populate the parser with core commands
         for cmd_name, cmd_mod in CORE_CMDS.items():
@@ -85,8 +85,11 @@ def execute(raw_args=sys.argv):
         autocomplete(parser)
         # Parse and run appropriate command
         args = parser.parse_args(remaining_args)
-        args.prog = "pubs"  # FIXME?
-        args.func(conf, args)
+        if not args.command:
+            parser.print_help()
+        else:
+            args.prog = "pubs"  # FIXME?
+            args.func(conf, args)
 
     except Exception as e:
         if not uis.get_ui().handle_exception(e):

--- a/pubs/pubs_cmd.py
+++ b/pubs/pubs_cmd.py
@@ -69,7 +69,6 @@ def execute(raw_args=sys.argv):
                                          prog="pubs", add_help=True)
         parser.add_argument('--version', action='version', version=__version__)
         subparsers = parser.add_subparsers(title="valid commands", dest="command")
-        #subparsers.required = True
 
         # Populate the parser with core commands
         for cmd_name, cmd_mod in CORE_CMDS.items():
@@ -86,11 +85,11 @@ def execute(raw_args=sys.argv):
 
         # Parse and run appropriate command
         # if no command, print help and exit peacefully (as '--help' does)
-        args = parser.parse_args(remaining_args)
-
+        args = parser.parse_args(remaining_args) 
         if not args.command:
-            parser.print_help()
-            sys.exit(0)
+            ui.error("Too few arguments!\n")
+            parser.print_help(file=sys.stderr)
+            sys.exit(2)
 
         args.prog = "pubs"  # FIXME?
         args.func(conf, args)

--- a/tests/fake_env.py
+++ b/tests/fake_env.py
@@ -90,7 +90,7 @@ class FakeInput():
 class TestFakeFs(fake_filesystem_unittest.TestCase):
 
     def setUp(self):
-        self.rootpath = os.path.dirname(__file__)
+        self.rootpath = os.path.abspath(os.path.dirname(__file__))
         self.setUpPyfakefs()
         self.fs.CreateDirectory(self.rootpath)
         os.chdir(self.rootpath)

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -187,13 +187,6 @@ class URLContentTestCase(DataCommandTestCase):
 
 # Actual tests
 
-class TestAlone(CommandTestCase):
-
-    def test_alone_misses_command(self):
-        with self.assertRaises(FakeSystemExit):
-            self.execute_cmds(['pubs'])
-
-
 class TestInit(CommandTestCase):
 
     def test_init(self):

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -29,14 +29,21 @@ PRINT_OUTPUT   = False
 CAPTURE_OUTPUT = True
 
 
-class FakeSystemExit(SystemExit):
+class FakeSystemExit(Exception):
     """\
     SystemExit exceptions are replaced by FakeSystemExit in the execute_cmds()
     function, so they can be catched by ExpectedFailure tests in Python 2.x.
 
     If a code is expected to raise SystemExit, catch FakeSystemExit instead.
+
+    Added explicit __init__ so SystemExit.code functionality could be emulated.
+    Taking form from https://stackoverflow.com/a/26938914/1634191
     """
-    pass
+    def __init__(self, message, code=None, *args):
+        self.message = message
+        self.code = code
+
+        super(FakeSystemExit, self).__init__(message, *args)
 
 
 # code for fake fs
@@ -131,7 +138,7 @@ class CommandTestCase(fake_env.TestFakeFs):
             exc_class, exc, tb = sys.exc_info()
             if sys.version_info.major == 2:
                 # using six to avoid a SyntaxError in Python 3.x
-                six.reraise(FakeSystemExit, *exc.args, exc_traceback=tb)
+                six.reraise(FakeSystemExit, FakeSystemExit(*exc.args), tb)
             else:
                 raise FakeSystemExit(*exc.args).with_traceback(tb)
 
@@ -189,6 +196,13 @@ class URLContentTestCase(DataCommandTestCase):
 
 class TestAlone(CommandTestCase):
 
+    def test_alone_misses_command(self):
+        with self.assertRaises(FakeSystemExit) as cm:
+            self.execute_cmds(['pubs'])
+            self.assertEqual(cm.exception.code, 2)
+
+
+    @unittest.skipIf(sys.version_info.major == 2, "not supported for Python2")
     def test_alone_prints_help(self):
         # capturing the output of `pubs --help` is difficult because argparse
         # raises as SystemExit(0) after calling `print_help`, and this gets
@@ -196,15 +210,14 @@ class TestAlone(CommandTestCase):
         # `pubs --help` isn't too easy unless substantially reorganization of
         # the parser and testing context is made.  instead, the exit codes of
         # the two usecases are compared.
-        self.execute_cmds(['pubs init'])
 
         with self.assertRaises(FakeSystemExit) as cm1:
             self.execute_cmds(['pubs'])
 
         with self.assertRaises(FakeSystemExit) as cm2:
-            self.execute_cmds(['pubs --help'])
+            self.execute_cmds(['pubs', '--help'])
 
-        self.assertEqual(cm1.exception.code, cm2.exception.code, 0)
+        self.assertEqual(cm1.exception.code, cm2.exception.code, 2)
 
 
 class TestInit(CommandTestCase):


### PR DESCRIPTION
This PR implements functionality discussed in Issue #99 for `pubs` to be called without a subcommand and it will print the help menu and exit.  This is similar behavior to how the git CLI functions.  A unittest has been modified to cover this behavior, though the test coverage isn't great due to difficulties with argparse's handing of the `-h/--help` flags.

