### PR TITLE
Feature: Alias descriptions in conf

### DIFF
--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -88,6 +88,13 @@ active = force_list(default=list('alias'))
 # shell commands can also be defined, by prefixing them with a bang `!`, e.g:
 # count = !pubs list -k | wc -l
 
+# aliases can also be defined with descriptions using the following configobj
+# subsectioning.  NOTE: any aliases defined this way should come after all other
+# aliases, otherwise simple aliases will be ignored.
+# [[[count]]]
+# command = !pubs list -k | wc -l
+# description = lists number of pubs in repo
+
 [internal]
 # The version of this configuration file. Do not edit.
 version = string(min=5, default='{}')

--- a/tests/test_plug_alias.py
+++ b/tests/test_plug_alias.py
@@ -104,6 +104,16 @@ class AliasPluginTestCase(unittest.TestCase):
         self.assertEqual(self.plugin.aliases[0].description, 'print this')
         self.assertEqual(self.plugin.aliases[0].definition, 'open -w lpppp')
 
+    def testAliasPluginNestedDefinitionNoDescription(self):
+        self.conf['plugins']['alias'] = {'print': {'command': 'open -w lpppp'}}
+        self.plugin = AliasPlugin(self.conf)
+        self.assertEqual(len(self.plugin.aliases), 1)
+        self.assertEqual(type(self.plugin.aliases[0]), CommandAlias)
+        self.assertEqual(self.plugin.aliases[0].name, 'print')
+        self.assertEqual(self.plugin.aliases[0].description,
+                         'user alias for `open -w lpppp`')
+        self.assertEqual(self.plugin.aliases[0].definition, 'open -w lpppp')
+
     def testAliasPluginMixedDefinitionTypes(self):
         self.conf['plugins']['alias'] = {'print': {'description': 'print this',
                                                    'command': 'open -w lpppp'},


### PR DESCRIPTION
See #98.

Allows aliases defined as currently supported and as subsections of the `[[alias]]` section of `conf.py` of the form:

    [[[alias-name]]]
    command = alias-command-definition
    description = alias-description

Note that aliases defined this way must be placed at the end of the `[[alias]]` section or they will gobble up aliases defined in the current format.  This is a limitation of ConfigObj sectioning.