### PR TITLE
Uses bibtexparser bwriter instead of internal encoder and adds `--ignore-fields` option to export.

### DIFF
--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+import argparse
+
 from .. import repo
 from ..uis import get_ui
 from .. import endecoder
@@ -7,8 +9,17 @@ from ..utils import resolve_citekey_list
 from ..completion import CiteKeyCompletion
 
 
+class CommaSeparatedList(argparse.Action):
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, [s for s in values.split(',') if s])
+
+
 def parser(subparsers, conf):
     parser = subparsers.add_parser('export', help='export bibliography')
+    parser.add_argument(
+        '--ignore-fields', default=[], action=CommaSeparatedList,
+        help='exclude field(s) from output (comma separated if multiple)')
     # parser.add_argument('-f', '--bib-format', default='bibtex',
     #         help='export format')
     parser.add_argument('citekeys', nargs='*', help='one or several citekeys'
@@ -36,7 +47,7 @@ def command(conf, args):
         bib[p.citekey] = p.bibdata
 
     exporter = endecoder.EnDecoder()
-    bibdata_raw = exporter.encode_bibdata(bib)
+    bibdata_raw = exporter.encode_bibdata(bib, args.ignore_fields)
     ui.message(bibdata_raw)
 
     rp.close()

--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -6,7 +6,8 @@ from .. import repo
 from ..uis import get_ui
 from .. import endecoder
 from ..utils import resolve_citekey_list
-from ..completion import CiteKeyCompletion
+from ..endecoder import BIBFIELD_ORDER
+from ..completion import CiteKeyCompletion, CommaSeparatedListCompletion
 
 
 class CommaSeparatedList(argparse.Action):
@@ -15,11 +16,17 @@ class CommaSeparatedList(argparse.Action):
         setattr(namespace, self.dest, [s for s in values.split(',') if s])
 
 
+class FieldCommaSeparatedListCompletion(CommaSeparatedListCompletion):
+
+    values = BIBFIELD_ORDER
+
+
 def parser(subparsers, conf):
     parser = subparsers.add_parser('export', help='export bibliography')
     parser.add_argument(
         '--ignore-fields', default=[], action=CommaSeparatedList,
-        help='exclude field(s) from output (comma separated if multiple)')
+        help='exclude field(s) from output (comma separated if multiple)'
+    ).completer = FieldCommaSeparatedListCompletion(conf)
     # parser.add_argument('-f', '--bib-format', default='bibtex',
     #         help='export format')
     parser.add_argument('citekeys', nargs='*', help='one or several citekeys'

--- a/pubs/completion.py
+++ b/pubs/completion.py
@@ -57,3 +57,15 @@ class TagModifierCompletion(BaseCompleter):
         partial_expr = prefix[:start]
         t_prefix = prefix[start:]
         return [partial_expr + t for t in tags if t.startswith(t_prefix)]
+
+
+class CommaSeparatedListCompletion(BaseCompleter):
+
+    values = []
+
+    def _complete(self, prefix, **kwargs):
+        split = prefix.split(',')
+        item_prefix = split[-1]
+        partial = split[:-1]
+        return [','.join(partial + [x]) for x in self.values
+                if x.startswith(item_prefix)]

--- a/pubs/endecoder.py
+++ b/pubs/endecoder.py
@@ -27,6 +27,11 @@ else:
     BP_ENTRYTYPE_KEY = 'type'
 
 
+BIBFIELD_ORDER = ['author', 'title', 'journal', 'institution', 'publisher',
+                  'year', 'month', 'number', 'volume', 'pages', 'link', 'doi',
+                  'note', 'abstract']
+
+
 def sanitize_citekey(record):
     record[BP_ID_KEY] = record[BP_ID_KEY].strip('\n')
     return record
@@ -54,11 +59,6 @@ def customizations(record):
     return record
 
 
-bibfield_order = ['author', 'title', 'journal', 'institution', 'publisher',
-                  'year', 'month', 'number', 'volume', 'pages', 'link', 'doi',
-                  'note', 'abstract']
-
-
 class EnDecoder(object):
     """ Encode and decode content.
 
@@ -71,7 +71,7 @@ class EnDecoder(object):
     """
 
     bwriter = bp.bwriter.BibTexWriter()
-    bwriter.display_order = bibfield_order
+    bwriter.display_order = BIBFIELD_ORDER
 
     def encode_metadata(self, metadata):
         return yaml.safe_dump(metadata, allow_unicode=True,

--- a/tests/test_endecoder.py
+++ b/tests/test_endecoder.py
@@ -91,12 +91,40 @@ class TestEnDecode(unittest.TestCase):
         self.assertIn(u'keyword', entry)
         self.assertEqual(set(keywords), set(entry[u'keyword']))
 
-
     def test_endecode_metadata(self):
         decoder = endecoder.EnDecoder()
         entry = decoder.decode_metadata(metadata_raw0)
         metadata_output0 = decoder.encode_metadata(entry)
         self.assertEqual(set(metadata_raw0.split('\n')), set(metadata_output0.split('\n')))
+
+    def test_endecode_bibtex_field_order(self):
+        decoder = endecoder.EnDecoder()
+        entry = decoder.decode_bibdata(bibtex_raw0)
+        lines = decoder.encode_bibdata(entry).splitlines()
+        self.assertEqual(lines[1].split('=')[0].strip(), u'author')
+        self.assertEqual(lines[2].split('=')[0].strip(), u'title')
+        self.assertEqual(lines[3].split('=')[0].strip(), u'institution')
+        self.assertEqual(lines[4].split('=')[0].strip(), u'publisher')
+        self.assertEqual(lines[5].split('=')[0].strip(), u'year')
+        self.assertEqual(lines[6].split('=')[0].strip(), u'month')
+        self.assertEqual(lines[7].split('=')[0].strip(), u'number')
+        self.assertEqual(lines[8].split('=')[0].strip(), u'link')
+        self.assertEqual(lines[9].split('=')[0].strip(), u'note')
+        self.assertEqual(lines[10].split('=')[0].strip(), u'abstract')
+
+    def test_endecode_bibtex_ignores_fields(self):
+        decoder = endecoder.EnDecoder()
+        entry = decoder.decode_bibdata(bibtex_raw0)
+
+        bibraw1 = decoder.encode_bibdata(
+            entry, ignore_fields=['title', 'note', 'abstract', 'journal'])
+        entry1 = list(decoder.decode_bibdata(bibraw1).values())[0]
+
+        self.assertNotIn('title', entry1)
+        self.assertNotIn('note', entry1)
+        self.assertNotIn('abtract', entry1)
+        self.assertIn('author', entry1)
+        self.assertIn('institution', entry1)
 
 
 if __name__ == '__main__':

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -669,6 +669,16 @@ class TestUsecase(DataCommandTestCase):
         self.assertEqual(endecoder.EnDecoder().decode_bibdata(outs[2]),
                          fixtures.page_bibentry)
 
+    def test_export_ignore_field(self):
+        cmds = ['pubs init',
+                ('pubs add', [str_fixtures.bibtex_external0]),
+                'pubs export --ignore-fields author,title Page99',
+                ]
+        outs = self.execute_cmds(cmds)
+        expected = endecoder.EnDecoder().encode_bibdata(
+            fixtures.page_bibentry, ignore_fields=['author', 'title'])
+        self.assertEqual(outs[2], expected + os.linesep)
+
     def test_import(self):
         cmds = ['pubs init',
                 'pubs import data/',


### PR DESCRIPTION
Fixes #33 and replaces #67.