### PR TITLE
Fixes unicode comparison

### DIFF
--- a/pubs/commands/list_cmd.py
+++ b/pubs/commands/list_cmd.py
@@ -15,6 +15,8 @@ def parser(subparsers, conf):
                         default=None, dest='case_sensitive')
     parser.add_argument('-I', '--force-case', action='store_true',
                         dest='case_sensitive')
+    parser.add_argument('--strict', action='store_true', default=False,
+                        help='force strict unicode comparison of query')
     parser.add_argument('-a', '--alphabetical', action='store_true',
                         dest='alphabetical', default=False,
                         help='lexicographic order on the citekeys.')
@@ -34,7 +36,8 @@ def command(conf, args):
     ui = get_ui()
     rp = repo.Repository(conf)
     papers = filter(get_paper_filter(args.query,
-                                     case_sensitive=args.case_sensitive),
+                                     case_sensitive=args.case_sensitive,
+                                     strict=args.strict),
                     rp.all_papers())
     if args.nodocs:
         papers = [p for p in papers if p.docpath is None]

--- a/pubs/query.py
+++ b/pubs/query.py
@@ -29,6 +29,9 @@ class QueryFilter(object):
     def __call__(self, paper):
         raise NotImplementedError
 
+    def _is_query_in(self, field_value):
+        return self.query in self._lower(field_value)
+
     def _lower(self, s):
         return s if self.case else s.lower()
 
@@ -42,7 +45,7 @@ class FieldFilter(QueryFilter):
 
     def __call__(self, paper):
         return (self.field in paper.bibdata and
-                self.query in self._lower(paper.bibdata[self.field]))
+                self._is_query_in(paper.bibdata[self.field]))
 
 
 class AuthorFilter(QueryFilter):
@@ -52,14 +55,14 @@ class AuthorFilter(QueryFilter):
         if 'author' not in paper.bibdata:
             return False
         else:
-            return any([self.query in self._lower(bibstruct.author_last(author))
+            return any([self._is_query_in(bibstruct.author_last(author))
                         for author in paper.bibdata['author']])
 
 
 class TagFilter(QueryFilter):
 
     def __call__(self, paper):
-        return any([self.query in self._lower(t) for t in paper.tags])
+        return any([self._is_query_in(t) for t in paper.tags])
 
 
 class YearFilter(QueryFilter):

--- a/pubs/query.py
+++ b/pubs/query.py
@@ -1,3 +1,4 @@
+from bibtexparser.latexenc import latex_to_unicode
 from . import bibstruct
 
 
@@ -24,15 +25,16 @@ class QueryFilter(object):
         if case_sensitive is None:
             case_sensitive = not query.islower()
         self.case = case_sensitive
-        self.query = self._lower(query)
+        self.query = self._normalize(query)
 
     def __call__(self, paper):
         raise NotImplementedError
 
     def _is_query_in(self, field_value):
-        return self.query in self._lower(field_value)
+        return self.query in self._normalize(field_value)
 
-    def _lower(self, s):
+    def _normalize(self, s):
+        s = latex_to_unicode(s)
         return s if self.case else s.lower()
 
 

--- a/pubs/query.py
+++ b/pubs/query.py
@@ -1,4 +1,7 @@
+import unicodedata
+
 from bibtexparser.latexenc import latex_to_unicode
+
 from . import bibstruct
 
 
@@ -34,7 +37,8 @@ class QueryFilter(object):
         return self.query in self._normalize(field_value)
 
     def _normalize(self, s):
-        s = latex_to_unicode(s)
+        s = unicodedata.normalize('NFC', latex_to_unicode(s))
+        # Note: in theory latex_to_unicode also normalizes
         return s if self.case else s.lower()
 
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -92,6 +92,12 @@ class TestCheckField(unittest.TestCase):
         self.assertTrue(
             FieldFilter('title', 'Gr{\\\"u}n')(latexenc_paper))
 
+    def test_normalize_unicode(self):
+        latexenc_paper = doe_paper.deepcopy()
+        latexenc_paper.bibentry['Doe2013']['title'] = "Jalape\u00f1o"
+        self.assertTrue(
+            FieldFilter('title', "Jalapen\u0303o")(latexenc_paper))
+
 
 class TestCheckQueryBlock(unittest.TestCase):
 
@@ -137,6 +143,11 @@ class TestFilterPaper(unittest.TestCase):
         self.assertTrue(get_paper_filter(['title:El'])(latexenc_paper))
         self.assertTrue(get_paper_filter(['title:Niño'])(latexenc_paper))
         self.assertTrue(get_paper_filter(['author:erdős'])(latexenc_paper))
+
+    def test_normalize_unicode(self):
+        latexenc_paper = doe_paper.deepcopy()
+        latexenc_paper.bibentry['Doe2013']['title'] = "{E}l Ni{\~n}o"
+        self.assertTrue(get_paper_filter(['title:Nin\u0303o'])(latexenc_paper))
 
 
 if __name__ == '__main__':

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -101,6 +101,22 @@ class TestCheckField(unittest.TestCase):
         self.assertTrue(
             FieldFilter('title', "Jalapen\u0303o")(latexenc_paper))
 
+    def test_strict(self):
+        latexenc_paper = doe_paper.deepcopy()
+        latexenc_paper.bibentry['Doe2013']['title'] = "Jalape\u00f1o"
+        self.assertFalse(FieldFilter('title', "Jalapen\u0303o",
+                                     strict=True)(latexenc_paper))
+        latexenc_paper.bibentry['Doe2013']['title'] = "{G}ros"
+        self.assertFalse(
+            FieldFilter('title', "Gros", strict=True)(latexenc_paper))
+
+    def test_strict_implies_case(self):
+        latexenc_paper = doe_paper.deepcopy()
+        latexenc_paper.bibentry['Doe2013']['title'] = "Gros"
+        self.assertFalse(
+            FieldFilter('title', "gros", case_sensitive=False,
+                        strict=True)(latexenc_paper))
+
 
 class TestCheckQueryBlock(unittest.TestCase):
 
@@ -146,11 +162,18 @@ class TestFilterPaper(unittest.TestCase):
         self.assertTrue(get_paper_filter(['title:El'])(latexenc_paper))
         self.assertTrue(get_paper_filter(['title:Niño'])(latexenc_paper))
         self.assertTrue(get_paper_filter(['author:erdős'])(latexenc_paper))
+        self.assertTrue(get_paper_filter(['title:{E}l'])(latexenc_paper))
 
     def test_normalize_unicode(self):
         latexenc_paper = doe_paper.deepcopy()
         latexenc_paper.bibentry['Doe2013']['title'] = "{E}l Ni{\~n}o"
         self.assertTrue(get_paper_filter(['title:Nin\u0303o'])(latexenc_paper))
+
+    def test_strict(self):
+        latexenc_paper = doe_paper.deepcopy()
+        latexenc_paper.bibentry['Doe2013']['title'] = "El Ni{\~n}o"
+        self.assertFalse(get_paper_filter(
+            ['title:Nin\u0303o'], strict=True)(latexenc_paper))
 
 
 if __name__ == '__main__':

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -84,6 +84,14 @@ class TestCheckField(unittest.TestCase):
         self.assertFalse(
             FieldFilter('title', 'nice', case_sensitive=True)(doe_paper))
 
+    def test_latex_enc(self):
+        latexenc_paper = doe_paper.deepcopy()
+        latexenc_paper.bibentry['Doe2013']['title'] = "{G}r{\\\"u}n"
+        self.assertTrue(
+            FieldFilter('title', 'Grün')(latexenc_paper))
+        self.assertTrue(
+            FieldFilter('title', 'Gr{\\\"u}n')(latexenc_paper))
+
 
 class TestCheckQueryBlock(unittest.TestCase):
 
@@ -121,6 +129,14 @@ class TestFilterPaper(unittest.TestCase):
         self.assertTrue(get_paper_filter(['author:doe', 'year:2010-2014'])(doe_paper))
         self.assertFalse(get_paper_filter(['author:doe', 'year:2014-'])(doe_paper))
         self.assertFalse(get_paper_filter(['author:doee', 'year:2014'])(doe_paper))
+
+    def test_latex_enc(self):
+        latexenc_paper = doe_paper.deepcopy()
+        latexenc_paper.bibentry['Doe2013']['title'] = "{E}l Ni{\~n}o"
+        latexenc_paper.bibentry['Doe2013']['author'][0] = "Erd\H{o}s, Paul"
+        self.assertTrue(get_paper_filter(['title:El'])(latexenc_paper))
+        self.assertTrue(get_paper_filter(['title:Niño'])(latexenc_paper))
+        self.assertTrue(get_paper_filter(['author:erdős'])(latexenc_paper))
 
 
 if __name__ == '__main__':

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,3 +1,6 @@
+# coding: utf8
+
+from __future__ import unicode_literals
 import unittest
 
 import dotdot

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -19,7 +19,7 @@ class TestAuthorFilter(unittest.TestCase):
 
     def test_fails_if_no_author(self):
         no_doe = doe_paper.deepcopy()
-        no_doe.bibentry['author'] = []
+        no_doe.bibentry['Doe2013']['author'] = []
         self.assertFalse(AuthorFilter('whatever')(no_doe))
 
     def test_match_case(self):

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -398,6 +398,33 @@ class TestList(DataCommandTestCase):
         outs = self.execute_cmds(cmds)
         self.assertEqual(0 + 1, len(outs[-1].split('\n')))
 
+    def test_list_strict_forces_case(self):
+        cmds = ['pubs init',
+                'pubs list',
+                'pubs import data/',
+                'pubs list --ignore-case --strict title:lAnguage',
+                ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual(0 + 1, len(outs[-1].split('\n')))
+
+    def test_list_strict(self):
+        cmds = ['pubs init',
+                'pubs list',
+                'pubs import data/',
+                'pubs list --strict title:{L}anguage',
+                ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual(0 + 1, len(outs[-1].split('\n')))
+
+    def test_list_latex_protection(self):
+        cmds = ['pubs init',
+                'pubs list',
+                'pubs import data/',
+                'pubs list title:{L}anguage',
+                ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual(1 + 1, len(outs[-1].split('\n')))
+
 
 class TestTag(DataCommandTestCase):
 


### PR DESCRIPTION
This PR adresses the first two elements mentioned in [my comment](https://github.com/pubs/pubs/issues/103#issuecomment-354887360) from #103.

The PR relies on recent additions to `bibtexparser` and some of the test rely on [python-bibtexparser#187](https://github.com/sciunto-org/python-bibtexparser/pull/187) being merged.This is why the tests don't pass.

This should probably be merged after `bibtexparser 0.6.3` is released.