### PR TITLE
Updates field orders to use 'url' and fixes broken test.

### DIFF
--- a/pubs/endecoder.py
+++ b/pubs/endecoder.py
@@ -28,8 +28,8 @@ else:
 
 
 BIBFIELD_ORDER = ['author', 'title', 'journal', 'institution', 'publisher',
-                  'year', 'month', 'number', 'volume', 'pages', 'link', 'doi',
-                  'note', 'abstract']
+                  'year', 'month', 'number', 'volume', 'pages', 'url', 'link',
+                  'doi', 'note', 'abstract']
 
 
 def sanitize_citekey(record):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
             ],
         },
 
-    install_requires=['pyyaml', 'bibtexparser', 'python-dateutil', 'requests',
+    install_requires=['pyyaml', 'bibtexparser>=1.0.1', 'python-dateutil', 'requests',
                       'configobj',
                       'beautifulsoup4'],  # to be made optional?
     tests_require=['pyfakefs>=2.7'],

--- a/tests/test_endecoder.py
+++ b/tests/test_endecoder.py
@@ -108,7 +108,7 @@ class TestEnDecode(unittest.TestCase):
         self.assertEqual(lines[5].split('=')[0].strip(), u'year')
         self.assertEqual(lines[6].split('=')[0].strip(), u'month')
         self.assertEqual(lines[7].split('=')[0].strip(), u'number')
-        self.assertEqual(lines[8].split('=')[0].strip(), u'link')
+        self.assertEqual(lines[8].split('=')[0].strip(), u'url')
         self.assertEqual(lines[9].split('=')[0].strip(), u'note')
         self.assertEqual(lines[10].split('=')[0].strip(), u'abstract')
 


### PR DESCRIPTION
The field ordering test was broken on the latest bibtexparser since it now replaces by default 'link' fields by 'url'.