### PR TITLE
Removes link and DOI customization. Fixes #119.

### DIFF
--- a/pubs/endecoder.py
+++ b/pubs/endecoder.py
@@ -50,9 +50,7 @@ def customizations(record):
     record = bp.customization.editor(record)
     record = bp.customization.journal(record)
     record = bp.customization.keyword(record)
-    record = bp.customization.link(record)
     record = bp.customization.page_double_hyphen(record)
-    record = bp.customization.doi(record)
 
     record = sanitize_citekey(record)
 
@@ -95,8 +93,6 @@ class EnDecoder(object):
         entry[BP_ENTRYTYPE_KEY] = entry.pop(TYPE_KEY)
         for f in ignore_fields:
             entry.pop(f, None)
-        if 'link' in entry:
-            entry['link'] = ', '.join(link['url'] for link in entry['link'])
         if 'author' in entry:
             entry['author'] = ' and '.join(
                 author for author in entry['author'])

--- a/tests/test_endecoder.py
+++ b/tests/test_endecoder.py
@@ -112,6 +112,18 @@ class TestEnDecode(unittest.TestCase):
         self.assertEqual(lines[9].split('=')[0].strip(), u'note')
         self.assertEqual(lines[10].split('=')[0].strip(), u'abstract')
 
+    def test_endecode_link_as_url(self):
+        decoder = endecoder.EnDecoder()
+        if 'url = ' not in bibtex_raw0:
+            raise NotImplementedError(
+                'The fixture bibraw0 has been changed; test needs an update.')
+        raw_with_link = bibtex_raw0.replace('url = ', 'link = ')
+        entry = decoder.decode_bibdata(raw_with_link)
+        lines = decoder.encode_bibdata(entry).splitlines()
+        self.assertEqual(lines[8].split('=')[0].strip(), u'url')
+        self.assertEqual(lines[8].split('=')[1].strip(),
+                         u'{http://ilpubs.stanford.edu:8090/422/},')
+
     def test_endecode_bibtex_ignores_fields(self):
         decoder = endecoder.EnDecoder()
         entry = decoder.decode_bibdata(bibtex_raw0)


### PR DESCRIPTION
See #119.

The issue of duplicated URLs was coming from the DOI customization. Introducing URLs from DOIs was duplicating the information in the bibtex (and causing the additional duplication of the url field on each write, as mentioned in #119).

The rational here is that there would be two reasons for including the DOI to URL customization:
1. **formatting DOIs as links in documents:**  this should rather be done in the tool (e.g. latex) formatting the document and not in pubs (or as an optional customization which is not the case now),
2. **pubs being able to look on the DOI page for a pdf or other information:** this is not used currently but should in any case not modify the underlying bibtex as the customization is doing now.

Both reasons would require something different then the current use of the customization. Hence the removal.