### PR TITLE
Fixes Travis failure on installing python3 for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
         - "3"
       before_install:
         - brew update
-        - brew install python3
+        - brew outdated python3 || brew install python3 || brew upgrade python3
+        - pip install -U virtualenv
         - virtualenv env -p python3
         - source env/bin/activate
 # command to install dependencies


### PR DESCRIPTION
```$ brew install python3
Error: python 2.7.14 is already installed
To upgrade to 3.6.4_3, run `brew upgrade python`
```