### PR TITLE
Fixes tests for printing help on `--help` and without argument.

### DIFF
--- a/pubs/pubs_cmd.py
+++ b/pubs/pubs_cmd.py
@@ -87,7 +87,7 @@ def execute(raw_args=sys.argv):
 
         # Parse and run appropriate command
         # if no command, print help and exit peacefully (as '--help' does)
-        args = parser.parse_args(remaining_args) 
+        args = parser.parse_args(remaining_args)
         if not args.command:
             ui.error("Too few arguments!\n")
             parser.print_help(file=sys.stderr)

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -39,11 +39,10 @@ class FakeSystemExit(Exception):
     Added explicit __init__ so SystemExit.code functionality could be emulated.
     Taking form from https://stackoverflow.com/a/26938914/1634191
     """
-    def __init__(self, message, code=None, *args):
-        self.message = message
+    def __init__(self, code=None, *args):
         self.code = code
-
-        super(FakeSystemExit, self).__init__(message, *args)
+        super(FakeSystemExit, self).__init__(
+            "Exited with code: {}.".format(self.code), *args)
 
 
 # code for fake fs
@@ -202,7 +201,6 @@ class TestAlone(CommandTestCase):
             self.assertEqual(cm.exception.code, 2)
 
 
-    @unittest.skipIf(sys.version_info.major == 2, "not supported for Python2")
     def test_alone_prints_help(self):
         # capturing the output of `pubs --help` is difficult because argparse
         # raises as SystemExit(0) after calling `print_help`, and this gets
@@ -210,14 +208,15 @@ class TestAlone(CommandTestCase):
         # `pubs --help` isn't too easy unless substantially reorganization of
         # the parser and testing context is made.  instead, the exit codes of
         # the two usecases are compared.
-
         with self.assertRaises(FakeSystemExit) as cm1:
             self.execute_cmds(['pubs'])
+        self.assertEqual(cm1.exception.code, 2)
 
+    def test_help_prints_help(self):
+        # see test_alone_prints_help
         with self.assertRaises(FakeSystemExit) as cm2:
-            self.execute_cmds(['pubs', '--help'])
-
-        self.assertEqual(cm1.exception.code, cm2.exception.code, 2)
+            self.execute_cmds(['pubs init', 'pubs --help'])
+        self.assertEqual(cm2.exception.code, 0)
 
 
 class TestInit(CommandTestCase):


### PR DESCRIPTION
(See #135 and #133)

**Notes:**
1. The tests still only check for exit codes.
2. If the repository is not initialized, `pubs --help` prints an error about the need to run `pubs init` instead of printing the actual help.