### PR TITLE
Add a command to open urls

### DIFF
--- a/pubs/commands/__init__.py
+++ b/pubs/commands/__init__.py
@@ -15,5 +15,6 @@ from . import export_cmd
 from . import import_cmd
 # bonus
 from . import websearch_cmd
+from . import url_cmd
 
 from . import edit_cmd

--- a/pubs/commands/url_cmd.py
+++ b/pubs/commands/url_cmd.py
@@ -2,23 +2,22 @@ from __future__ import unicode_literals
 
 import webbrowser
 
-from .. import p3
 from .. import repo
 from ..uis import get_ui
-from ..utils import resolve_citekey, resolve_citekey_list
+from ..utils import resolve_citekey_list
 
 
 
 def parser(subparsers, conf):
     parser = subparsers.add_parser('url',
-                                   help="open the url in the browser")
+                                   help="open a paper's url in the default web browser")
     parser.add_argument("citekey", nargs = '*',
                         help="one or more citeKeys to open")
     return parser
 
 
 def command(conf, args):
-    """Open the url for a publication."""
+    """Open the url of one or several papers in a web browser."""
 
     ui = get_ui()
     rp = repo.Repository(conf)
@@ -27,6 +26,7 @@ def command(conf, args):
         try:
             paper = rp.pull_paper(key)
             url = paper.bibdata['url']
+            ui.info('opening url {}'.format(url))
             webbrowser.open(url)
 
         except KeyError as e:

--- a/pubs/commands/url_cmd.py
+++ b/pubs/commands/url_cmd.py
@@ -23,13 +23,13 @@ def command(conf, args):
     ui = get_ui()
     rp = repo.Repository(conf)
 
-    for key in resolve_citekey_list(rp, args.citekey, ui=ui, exit_on_fail=True):
+    for key in resolve_citekey_list(rp, args.citekey, ui=ui, exit_on_fail=False):
         try:
             paper = rp.pull_paper(key)
             url = paper.bibdata['url']
             webbrowser.open(url)
 
         except KeyError as e:
-            ui.error('{} has no url'.format(key))
+            ui.warning('{} has no url'.format(key))
 
     rp.close()

--- a/pubs/commands/url_cmd.py
+++ b/pubs/commands/url_cmd.py
@@ -1,0 +1,35 @@
+from __future__ import unicode_literals
+
+import webbrowser
+
+from .. import p3
+from .. import repo
+from ..uis import get_ui
+from ..utils import resolve_citekey, resolve_citekey_list
+
+
+
+def parser(subparsers, conf):
+    parser = subparsers.add_parser('url',
+                                   help="open the url in the browser")
+    parser.add_argument("citekey", nargs = '*',
+                        help="one or more citeKeys to open")
+    return parser
+
+
+def command(conf, args):
+    """Open the url for a publication."""
+
+    ui = get_ui()
+    rp = repo.Repository(conf)
+
+    for key in resolve_citekey_list(rp, args.citekey, ui=ui, exit_on_fail=True):
+        try:
+            paper = rp.pull_paper(key)
+            url = paper.bibdata['url']
+            webbrowser.open(url)
+
+        except KeyError as e:
+            ui.error(key, 'has no url')
+
+    rp.close()

--- a/pubs/commands/url_cmd.py
+++ b/pubs/commands/url_cmd.py
@@ -31,6 +31,5 @@ def command(conf, args):
 
         except KeyError as e:
             ui.error('{} has no url'.format(key))
-            print(key)
 
     rp.close()

--- a/pubs/commands/url_cmd.py
+++ b/pubs/commands/url_cmd.py
@@ -30,6 +30,7 @@ def command(conf, args):
             webbrowser.open(url)
 
         except KeyError as e:
-            ui.error(key, 'has no url')
+            ui.error('{} has no url'.format(key))
+            print(key)
 
     rp.close()

--- a/pubs/pubs_cmd.py
+++ b/pubs/pubs_cmd.py
@@ -29,6 +29,7 @@ CORE_CMDS = collections.OrderedDict([
     ('import', commands.import_cmd),
 
     ('websearch', commands.websearch_cmd),
+    ('url', commands.url_cmd),
     ('edit', commands.edit_cmd),
 ])
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@
 six
 pyfakefs==3.3
 ddt
+mock

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -508,13 +508,11 @@ class TestURL(DataCommandTestCase):
                 'pubs add data/turing1950.bib',
                 'pubs add data/martius.bib',
                 ]
-        #self.fs.add_real_file('/dev/null')
-        #webbrowser.register('true', None, webbrowser.GenericBrowser('/usr/bin/true'), -1)
         self.execute_cmds(init)
 
     @mock.patch('webbrowser.open')
     def test_url_open_one(self, wb_open):
-        cmds = [('pubs url Page99', 'qy'),
+        cmds = ['pubs url Page99',
                 ]
         correct = ['info: opening url http://ilpubs.stanford.edu:8090/422/\n',
                    ]
@@ -529,7 +527,7 @@ class TestURL(DataCommandTestCase):
 
     @mock.patch('webbrowser.open')
     def test_url_open_multiple(self, wb_open):
-        cmds = [('pubs url Page99 10.1371_journal.pone.0063400', 'qyqy'),
+        cmds = ['pubs url Page99 10.1371_journal.pone.0063400',
                 ]
         correct = ['info: opening url http://ilpubs.stanford.edu:8090/422/\n' +
                    'info: opening url http://dx.doi.org/10.1371%2Fjournal.pone.0063400\n',

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -154,7 +154,6 @@ class DataCommandTestCase(CommandTestCase):
         super(DataCommandTestCase, self).setUp(nsec_stat=nsec_stat)
         self.fs.add_real_directory(os.path.join(self.rootpath, 'data'), read_only=False)
         self.fs.add_real_directory(os.path.join(self.rootpath, 'bibexamples'), read_only=False)
-        self.fs.CreateFile('/dev/null')
 
         # fake_env.copy_dir(self.fs, os.path.join(os.path.dirname(__file__), 'data'), 'data')
         # fake_env.copy_dir(self.fs, os.path.join(os.path.dirname(__file__), 'bibexamples'), 'bibexamples')


### PR DESCRIPTION
Hello pubs maintainers,

I just recently found this project and really enjoy using it.

I thought a useful command would be to open up the url field in a web browser.
This will help with things like filling out docs.

For the brave:
`pubs list -k --no-docs | xargs pubs url`
Note: This crashed Firefox on my machine the first time I ran it (though it did succeed later attempts).
I can, however recommend
 `pubs list -k --no-docs | head | xargs pubs url`
Which will limit the number of tabs open.

Thanks,
Kyle
