### PR TITLE
Arxiv support for pubs add.

### DIFF
--- a/pubs/apis.py
+++ b/pubs/apis.py
@@ -40,19 +40,20 @@ def arxiv2bibtex(arxiv_id):
     if 'title' not in entry:
         ui = get_ui()
         ui.error('malformed arXiv ID: {}'.format(arxiv_id))
-    if 'arxiv_doi' in entry:
-        return doi2bibtex(entry['arxiv_doi'])
+        bibtex = None
+    elif 'arxiv_doi' in entry:
+        bibtex = doi2bibtex(entry['arxiv_doi'])
     else:
         # Create a bibentry from the metadata.
-        bibtext = '@misc{{{},\n'.format(arxiv_id)
-        bibtext += 'Author = {'
+        bibtex = '@misc{{{},\n'.format(arxiv_id)
+        bibtex += 'Author = {'
         for i, author in enumerate(entry['authors']):
-            bibtext += author['name']
+            bibtex += author['name']
             if i < len(entry['authors']) - 1:
-                bibtext += ' and '
-        bibtext += '},\n'
-        bibtext += 'Title = {{{}}},\n'.format(entry['title'].strip('\n'))
-        bibtext += 'Year = {{{}}},\n'.format(entry['published_parsed'].tm_year)
-        bibtext += 'Eprint = {{arXiv:{}}},\n'.format(arxiv_id)
-        bibtext += '}'
-        return bibtext
+                bibtex += ' and '
+        bibtex += '},\n'
+        bibtex += 'Title = {{{}}},\n'.format(entry['title'].strip('\n'))
+        bibtex += 'Year = {{{}}},\n'.format(entry['published_parsed'].tm_year)
+        bibtex += 'Eprint = {{arXiv:{}}},\n'.format(arxiv_id)
+        bibtex += '}'
+    return bibtex

--- a/pubs/apis.py
+++ b/pubs/apis.py
@@ -1,7 +1,9 @@
 """Interface for Remote Bibliographic APIs"""
 
 import requests
+import feedparser
 from bs4 import BeautifulSoup
+from uis import get_ui
 
 
 def doi2bibtex(doi):
@@ -25,3 +27,32 @@ def isbn2bibtex(isbn):
     citation = soup.find("textarea").text
 
     return citation
+
+
+def arxiv2bibtex(arxiv_id):
+    """Return a bibtex string of metadata from an arXiv ID"""
+
+    url = 'https://export.arxiv.org/api/query?id_list=' + arxiv_id
+    r = requests.get(url)
+    feed = feedparser.parse(r.text)
+    entry = feed.entries[0]
+
+    if 'title' not in entry:
+        ui = get_ui()
+        ui.error('malformed arXiv ID: {}'.format(arxiv_id))
+    if 'arxiv_doi' in entry:
+        return doi2bibtex(entry['arxiv_doi'])
+    else:
+        # Create a bibentry from the metadata.
+        bibtext = '@misc{{{},\n'.format(arxiv_id)
+        bibtext += 'Author = {'
+        for i, author in enumerate(entry['authors']):
+            bibtext += author['name']
+            if i < len(entry['authors']) - 1:
+                bibtext += ' and '
+        bibtext += '},\n'
+        bibtext += 'Title = {{{}}},\n'.format(entry['title'].strip('\n'))
+        bibtext += 'Year = {{{}}},\n'.format(entry['published_parsed'].tm_year)
+        bibtext += 'Eprint = {{arXiv:{}}},\n'.format(arxiv_id)
+        bibtext += '}'
+        return bibtext

--- a/pubs/commands/add_cmd.py
+++ b/pubs/commands/add_cmd.py
@@ -84,28 +84,33 @@ def command(conf, args):
 
     # get bibtex entry
     if bibfile is None:
-        if args.doi is None and args.isbn is None:
+        if args.doi is None and args.isbn is None and args.arxiv is None:
             bibentry = bibentry_from_editor(conf, ui, rp)
         else:
             bibentry = None
-            if args.doi is not None:
-                bibentry_raw = apis.doi2bibtex(args.doi)
-                bibentry = rp.databroker.verify(bibentry_raw)
-                if bibentry is None:
-                    ui.error('invalid doi {} or unable to retrieve bibfile from it.'.format(args.doi))
-            if args.isbn is not None:
-                bibentry_raw = apis.isbn2bibtex(args.isbn)
-                bibentry = rp.databroker.verify(bibentry_raw)
-                if bibentry is None:
-                    ui.error('invalid isbn {} or unable to retrieve bibfile from it.'.format(args.isbn))
-                # TODO distinguish between cases, offer to open the error page in a webbrowser.
-                # TODO offer to confirm/change citekey
-            if args.arxiv is not None:
-                bibentry_raw = apis.arxiv2bibtex(args.arxiv)
-                bibentry = rp.databroker.verify(bibentry_raw)
-                if bibentry is None:
-                    ui.error('invalid arxiv id {} or unable to retrieve bibfile from it.'.format(args.arxiv_id))
-            if bibentry is None:
+            try:
+                if args.doi is not None:
+                    bibentry_raw = apis.doi2bibtex(args.doi)
+                    bibentry = rp.databroker.verify(bibentry_raw)
+                    if bibentry is None:
+                        raise apis.ReferenceNotFoundException(
+                            'invalid doi {} or unable to retrieve bibfile from it.'.format(args.doi))
+                elif args.isbn is not None:
+                    bibentry_raw = apis.isbn2bibtex(args.isbn)
+                    bibentry = rp.databroker.verify(bibentry_raw)
+                    if bibentry is None:
+                        raise apis.ReferenceNotFoundException(
+                            'invalid isbn {} or unable to retrieve bibfile from it.'.format(args.isbn))
+                    # TODO distinguish between cases, offer to open the error page in a webbrowser.
+                    # TODO offer to confirm/change citekey
+                elif args.arxiv is not None:
+                    bibentry_raw = apis.arxiv2bibtex(args.arxiv)
+                    bibentry = rp.databroker.verify(bibentry_raw)
+                    if bibentry is None:
+                        raise apis.ReferenceNotFoundException(
+                            'invalid arxiv id {} or unable to retrieve bibfile from it.'.format(args.arxiv_id))
+            except apis.ReferenceNotFoundException as e:
+                ui.error(e.message)
                 ui.exit(1)
     else:
         bibentry_raw = content.get_content(bibfile, ui=ui)

--- a/pubs/commands/add_cmd.py
+++ b/pubs/commands/add_cmd.py
@@ -68,19 +68,6 @@ def bibentry_from_editor(conf, ui, rp):
     return bibentry
 
 
-def api_call(fn, arg):
-    """Calls the appropriate API command.
-
-    :param fn: The API function to call.
-    :param arg: The argument to give the API call.
-    """
-    bibentry_raw = fn(arg)
-    bibentry = rp.databroker.verify(bibentry_raw)
-    return bibentry
-    if bibentry is None:
-        ui.error('invalid doi {} or unable to retrieve bibfile from it.'.format(args.doi))
-
-
 def command(conf, args):
     """
     :param bibfile: bibtex file (in .bib, .bibml or .yaml format.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dateutil
 requests
 configobj
 beautifulsoup4
+feedparser

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -7,7 +7,7 @@ import dotdot
 
 from pubs.p3 import ustr
 from pubs.endecoder import EnDecoder
-from pubs.apis import doi2bibtex, isbn2bibtex
+from pubs.apis import arxiv2bibtex, doi2bibtex, isbn2bibtex
 
 
 class TestDOI2Bibtex(unittest.TestCase):
@@ -58,6 +58,31 @@ class TestISBN2Bibtex(unittest.TestCase):
         bib = doi2bibtex('9' * 13)
         with self.assertRaises(ValueError):
             self.endecoder.decode_bibdata(bib)
+
+
+class TestArxiv2Bibtex(unittest.TestCase):
+
+    def setUp(self):
+        self.endecoder = EnDecoder()
+
+    def test_parses_to_bibtex_with_doi(self):
+        bib = arxiv2bibtex('astro-ph/9812133')
+        b = self.endecoder.decode_bibdata(bib)
+        self.assertEqual(len(b), 1)
+        entry = b[list(b)[0]]
+        self.assertEqual(entry['author'][0], 'Perlmutter, S.')
+        self.assertEqual(entry['year'], '1999')
+
+    def test_parses_to_bibtex_without_doi(self):
+        bib = arxiv2bibtex('math/0211159')
+        b = self.endecoder.decode_bibdata(bib)
+        self.assertEqual(len(b), 1)
+        entry = b[list(b)[0]]
+        self.assertEqual(entry['author'][0], 'Perelman, Grisha')
+        self.assertEqual(entry['year'], '2002')
+        self.assertEqual(
+                entry['title'],
+                'The entropy formula for the Ricci flow and its geometric applications')
 
 
 # Note: apparently ottobib.com uses caracter modifiers for accents instead


### PR DESCRIPTION
This addresses issue #145 by adding arXiv support for the `pubs add` command.  Now a user can add a paper using its arXiv ID with

```
pubs add --arxiv 1234.1234
```

or

```
pubs add -X 1234.1234
```

If the arXiv paper has a DOI associated with it (according to the arXiv API), the usual DOI API call will be used to generate the bibtex.  If there is no DOI associated with it then it will generate a bibtex entry on its own.