### PR TITLE
Fix/pyfakefs37

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,8 @@
 
 ### Fixed bugs
 
+- [[#148]](https://github.com/pubs/pubs/issues/148) Fix compatibility with Pyfakefs 3.7 [(#151)](https://github.com/pubs/pubs/pull/151)
+
 - [[#95]](https://github.com/pubs/pubs/issues/95) Error message when editor is missing [(#141)](https://github.com/pubs/pubs/issues/141)
 
 - Fixes tests for printing help on `--help` and without argument. [(#137)](https://github.com/pubs/pubs/issues/137)

--- a/pubs/uis.py
+++ b/pubs/uis.py
@@ -46,9 +46,6 @@ def _get_local_editor():
 def _editor_input(editor, initial='', suffix='.tmp'):
     """Use an editor to get input"""
     str_initial = initial.encode('utf-8')  # TODO: make it a configuration item
-    # tfile_name = '/tmp/pubs.tmp'
-    # with open(tfile_name, 'w') as temp_file:
-    #     temp_file.write(str_initial)
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
         tfile_name = temp_file.name
         temp_file.write(str_initial)

--- a/pubs/uis.py
+++ b/pubs/uis.py
@@ -46,6 +46,9 @@ def _get_local_editor():
 def _editor_input(editor, initial='', suffix='.tmp'):
     """Use an editor to get input"""
     str_initial = initial.encode('utf-8')  # TODO: make it a configuration item
+    # tfile_name = '/tmp/pubs.tmp'
+    # with open(tfile_name, 'w') as temp_file:
+    #     temp_file.write(str_initial)
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
         tfile_name = temp_file.name
         temp_file.write(str_initial)

--- a/tests/fake_env.py
+++ b/tests/fake_env.py
@@ -101,16 +101,12 @@ class TestFakeFs(fake_filesystem_unittest.TestCase):
         self.homepath = os.path.expanduser('~')
         self.setUpPyfakefs()
         self.reset_fs()
-        # self.fs.create_dir(os.path.expanduser('~'))
-        # self.fs.create_dir(self.rootpath)
-        # os.chdir(self.rootpath)
-
 
     def reset_fs(self):
-        if self.fs.isdir(self.homepath):
-            self.fs.remove_object(self.homepath)
-        if self.fs.isdir(self.rootpath):
-            self.fs.remove_object(self.rootpath)
+        """Reset the fake filesystem"""
+        for dir_name in self.fs.listdir('/'):
+            if dir_name not in ['var', 'tmp']:
+                self.fs.remove_object(os.path.join('/', dir_name))
 
         self.fs.create_dir(os.path.expanduser('~'))
         self.fs.create_dir(self.rootpath)

--- a/tests/fake_env.py
+++ b/tests/fake_env.py
@@ -98,11 +98,20 @@ class TestFakeFs(fake_filesystem_unittest.TestCase):
 
     def setUp(self):
         self.rootpath = os.path.abspath(os.path.dirname(__file__))
+        self.homepath = os.path.expanduser('~')
         self.setUpPyfakefs()
-        self.fs.CreateDirectory(os.path.expanduser('~'))
-        self.fs.CreateDirectory(self.rootpath)
-        os.chdir(self.rootpath)
+        self.reset_fs()
+        # self.fs.create_dir(os.path.expanduser('~'))
+        # self.fs.create_dir(self.rootpath)
+        # os.chdir(self.rootpath)
+
 
     def reset_fs(self):
-        self._stubber.tearDown()  # renew the filesystem
-        self.setUp()
+        if self.fs.isdir(self.homepath):
+            self.fs.remove_object(self.homepath)
+        if self.fs.isdir(self.rootpath):
+            self.fs.remove_object(self.rootpath)
+
+        self.fs.create_dir(os.path.expanduser('~'))
+        self.fs.create_dir(self.rootpath)
+        os.chdir(self.rootpath)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 # those are the additional packages required to run the tests
 six
-pyfakefs==3.3
+pyfakefs
 ddt
 mock

--- a/tests/test_bibstruct.py
+++ b/tests/test_bibstruct.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import os
 import unittest
 import copy
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 import unittest
 
 import dotdot
-from pubs.config import conf
+# from pubs.config import conf
 
 # class TestConfig(unittest.TestCase):
 #

--- a/tests/test_databroker.py
+++ b/tests/test_databroker.py
@@ -90,4 +90,4 @@ class TestDataBroker(fake_env.TestFakeFs):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/tests/test_databroker.py
+++ b/tests/test_databroker.py
@@ -5,8 +5,7 @@ import os
 import dotdot
 import fake_env
 
-from pubs import content, filebroker, databroker, datacache
-from pubs.config import conf
+from pubs import content, databroker, datacache
 
 import str_fixtures
 from pubs import endecoder
@@ -35,7 +34,7 @@ class TestDataBroker(fake_env.TestFakeFs):
 
             self.assertEqual(db.pull_metadata('citekey1'), page99_metadata)
             pulled = db.pull_bibentry('citekey1')['Page99']
-            for key, value in pulled.items():
+            for key in pulled.keys():
                 self.assertEqual(pulled[key], page99_bibentry['Page99'][key])
             self.assertEqual(db.pull_bibentry('citekey1'), page99_bibentry)
 

--- a/tests/test_datacache.py
+++ b/tests/test_datacache.py
@@ -3,7 +3,6 @@ import unittest
 import time
 
 import dotdot
-import fake_env
 
 from pubs.datacache import CacheEntrySet
 

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -1,10 +1,8 @@
 from __future__ import unicode_literals
 
 import unittest
-import os
 
 import dotdot
-import fake_env
 
 from pubs import endecoder, pretty, color, config
 

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -15,14 +15,12 @@ from pyfakefs.fake_filesystem import FakeFileOpen
 import dotdot
 import fake_env
 
-from pubs import pubs_cmd, update, color, content, filebroker, uis, p3, endecoder
+from pubs import pubs_cmd, color, content, uis, p3, endecoder
 from pubs.config import conf
-import configobj
 
 import str_fixtures
 import fixtures
 
-from pubs.commands import init_cmd, import_cmd
 
 # makes the tests very noisy
 PRINT_OUTPUT   = False
@@ -66,12 +64,12 @@ class TestFakeInput(unittest.TestCase):
 
     def test_editor_input(self):
         other_input = fake_env.FakeInput(['yes', 'no'],
-                                         module_list=[uis, color])
+                                         module_list=[uis])
         other_input.as_global()
-        self.assertEqual(uis._editor_input(), 'yes')
-        self.assertEqual(uis._editor_input(), 'no')
+        self.assertEqual(uis._editor_input('fake_editor'), 'yes')
+        self.assertEqual(uis._editor_input('fake_editor'), 'no')
         with self.assertRaises(fake_env.FakeInput.UnexpectedInput):
-            color.input()
+            uis._editor_input()
 
 
 class CommandTestCase(fake_env.TestFakeFs):
@@ -82,7 +80,6 @@ class CommandTestCase(fake_env.TestFakeFs):
     def setUp(self, nsec_stat=True):
         super(CommandTestCase, self).setUp()
         os.stat_float_times(nsec_stat)
-        # self.fs = fake_env.create_fake_fs([content, filebroker, conf, init_cmd, import_cmd, configobj, update], nsec_stat=nsec_stat)
         self.default_pubs_dir = os.path.expanduser('~/.pubs')
         self.default_conf_path = os.path.expanduser('~/.pubsrc')
 
@@ -178,7 +175,7 @@ class URLContentTestCase(DataCommandTestCase):
         return p3.urlparse(url).path
 
     def url_exists(self, url):
-        return self.fs.Exists(self._url_to_path(url))
+        return self.fs.exists(self._url_to_path(url))
 
     def url_to_byte_content(self, url, ui=None):
         path = self._url_to_path(url)
@@ -920,4 +917,4 @@ class TestCache(DataCommandTestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Ok, that should work now. Pyfakefs is at the latest version. 

By the way, Python 3.3 has reached end-of-life in 2017 (https://www.python.org/downloads/release/python-337/), using it is not recommended, and supporting it should not be a priority anymore for us. As long as it works... 