### PR TITLE
Fixed argument passing for alias plugin

### DIFF
--- a/pubs/plugs/alias/alias.py
+++ b/pubs/plugs/alias/alias.py
@@ -55,7 +55,7 @@ class ShellAlias(Alias):
         as shell arguments.
         """
         subprocess.call(
-            'pubs_alias_fun () {{\n{}\n}}\npubs_alias_fun {}'.format(
+            'pubs_alias_fun () {{\n{} $@\n}}\npubs_alias_fun {}'.format(
                 self.definition,
                 ' '.join([shell_quote(a) for a in args.arguments])
             ), shell=True)


### PR DESCRIPTION
_(Disregard this if it wasn't intended)_
I was going through the alias code and realized that shell command doesn't use its arguments passed to it via the `.format()` function.