### PR TITLE
Add CitekeyFilter and FIELD_ALIAS 'key': 'citekey' to query.py

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 
 ### Implemented enhancements
 
+- Add `citekey` filter to `query` ([#193](https://github.com/pubs/pubs/pull/193) by [Shane Stone](https://github.com/shanewstone))
+
 
 ### Fixed bugs
 

--- a/pubs/query.py
+++ b/pubs/query.py
@@ -15,6 +15,7 @@ FIELD_ALIASES = {
     't': 'title',
     'tags': 'tag',
     'y': 'year',
+    'key': 'citekey',
 }
 
 
@@ -78,6 +79,12 @@ class AuthorFilter(QueryFilter):
                         for author in paper.bibdata['author']])
 
 
+class CitekeyFilter(QueryFilter):
+
+    def __call__(self, paper):
+        return self._is_query_in(paper.citekey)
+
+
 class TagFilter(QueryFilter):
 
     def __call__(self, paper):
@@ -137,6 +144,9 @@ def _query_block_to_filter(query_block, case_sensitive=None, strict=False):
     field, value = _get_field_value(query_block)
     if field == 'tag':
         return TagFilter(value, case_sensitive=case_sensitive, strict=strict)
+    elif field == 'citekey':
+        return CitekeyFilter(value, case_sensitive=case_sensitive,
+                            strict=strict)
     elif field == 'author':
         return AuthorFilter(value, case_sensitive=case_sensitive,
                             strict=strict)

--- a/pubs/query.py
+++ b/pubs/query.py
@@ -6,7 +6,8 @@ from . import bibstruct
 
 
 QUERY_HELP = ('Paper query ("author:Einstein", "title:learning",'
-              '"year:2000", "year:2000-2010", or "tags:math")')
+              ' "year:2000", "year:2000-2010", "citekey:Einstein_1935",'
+              ' or "tags:math")')
 
 
 FIELD_ALIASES = {

--- a/pubs/query.py
+++ b/pubs/query.py
@@ -147,7 +147,7 @@ def _query_block_to_filter(query_block, case_sensitive=None, strict=False):
         return TagFilter(value, case_sensitive=case_sensitive, strict=strict)
     elif field == 'citekey':
         return CitekeyFilter(value, case_sensitive=case_sensitive,
-                            strict=strict)
+                             strict=strict)
     elif field == 'author':
         return AuthorFilter(value, case_sensitive=case_sensitive,
                             strict=strict)

--- a/readme.md
+++ b/readme.md
@@ -142,3 +142,4 @@ You can access the self-documented configuration by using `pubs conf`, and all t
 - [Dennis Wilson](https://github.com/d9w)
 - [Bill Flynn](https://github.com/wflynny)
 - [ksunden](https://github.com/ksunden)
+- [Shane Stone](https://github.com/shanewstone)

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -505,6 +505,18 @@ class TestList(DataCommandTestCase):
         outs = self.execute_cmds(cmds)
         self.assertEqual(1 + 1, len(outs[-1].split('\n')))
 
+    def test_list_with_citekey_query(self):
+        cmds = ['pubs init',
+                'pubs import data/',
+                'pubs list citekey:Page99',
+                'pubs list key:eiNstein_1935',
+                'pubs list --ignore-case key:eiNstein_1935',
+                ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual(1, len(outs[2].splitlines()))
+        self.assertEqual(0, len(outs[3].splitlines()))
+        self.assertEqual(1, len(outs[4].splitlines()))
+
 
 class TestTag(DataCommandTestCase):
 


### PR DESCRIPTION
Thank you for writing and maintaining `pubs`!

This PR is a simple addition to `query.py` which enables users to query the publication database using citekeys. This is useful because the citekey is the unique identifier used to interact with each publication, e.g. through `pubs doc open`. Citekey queries are different than author queries, since a citekey query can achieve more specificity in just a few characters: as an example, `pubs list citekey:Fox201` returns all first-authored papers by Fox in the 2010s. Further, I keep track of papers in my head by first author and year, so this just seems natural to me and I would assume it would feel natural to others as well.

As part of the change, I added `key` as an alias for `citekey` to enable shorter commands like `pubs list key:Fox201`.

(Note that the general `FieldFilter` does not currently work for citekeys since `FieldFilter` only looks through `paper.bibdata`.)