### PR TITLE
Fix test broken likely by pyyaml update by making it more explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
 # command to run tests
 script:
   - python --version
-  - if [ "$TO_TEST" = "TEST_FULL" ]; then PUBS_TESTS_MODE=MOCK    python setup.py test; fi
+  - if [ "$TO_TEST" = "TEST_MOCK" ] ||
+       [ "$TO_TEST" = "TEST_FULL" ]; then PUBS_TESTS_MODE=MOCK    python setup.py test; fi
   - if [ "$TO_TEST" = "TEST_FULL" ]; then PUBS_TESTS_MODE=COLLECT python setup.py test; fi
-  - if [ "$TO_TEST" = "TEST_MOCK" ]; then PUBS_TESTS_MODE=MOCK    python setup.py test; fi
   - if [ "$TO_TEST" = "INSTALL" ]; then pip install -U pip && pip install pubs && pubs --help && pip uninstall -y pubs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,14 @@ matrix:
       python: 3.6
       env:
         - TO_TEST=TEST_MOCK
+    - os: linux
+      language: python
+      dist: xenial
+      python: 3.7
+      sudo: true
+      env:
+        - TO_TEST=TEST_MOCK
+
 
     # Install tests
     - os: linux

--- a/tests/test_endecoder.py
+++ b/tests/test_endecoder.py
@@ -26,7 +26,7 @@ class TestEnDecode(unittest.TestCase):
     def test_decode_emptystring(self):
         decoder = endecoder.EnDecoder()
         with self.assertRaises(decoder.BibDecodingError):
-            entry = decoder.decode_bibdata('')
+            decoder.decode_bibdata('')
 
     def test_encode_bibtex_is_unicode(self):
         decoder = endecoder.EnDecoder()
@@ -117,11 +117,21 @@ class TestEnDecode(unittest.TestCase):
         self.assertIn('keyword', entry)
         self.assertEqual(set(keywords), set(entry['keyword']))
 
+    def test_decode_metadata(self):
+        decoder = endecoder.EnDecoder()
+        entry = decoder.decode_metadata(metadata_raw0)
+        expected = {'docfile': 'docsdir://Page99.pdf',
+                    'tags': ['search', 'network'],
+                    'added': '2013-11-14 13:14:20',
+                    }
+        self.assertEqual(entry, expected)
+
     def test_endecode_metadata(self):
         decoder = endecoder.EnDecoder()
         entry = decoder.decode_metadata(metadata_raw0)
         metadata_output0 = decoder.encode_metadata(entry)
-        self.assertEqual(set(metadata_raw0.split('\n')), set(metadata_output0.split('\n')))
+        entry_from_encode = decoder.decode_metadata(metadata_output0)
+        self.assertEqual(entry, entry_from_encode)
 
     def test_endecode_bibtex_field_order(self):
         decoder = endecoder.EnDecoder()


### PR DESCRIPTION
- does not test a specific output from pyyaml dump anymore,
- explicitely check decode and encode-decode step.

As an alternative (or in an other PR) we could set our own "canonical" format for pyyaml.