### PR TITLE
ENH: Don't fail on import, warn instead

### DIFF
--- a/pubs/commands/import_cmd.py
+++ b/pubs/commands/import_cmd.py
@@ -104,7 +104,14 @@ def command(conf, args):
     keys = args.keys or papers.keys()
     for k in keys:
         p = papers[k]
-        rp.push_paper(p, overwrite=args.overwrite)
+        try:
+            rp.push_paper(p, overwrite=args.overwrite)
+        except repo.CiteKeyCollision:
+            ui.warning("{} already in repository, use '-O' to overwrite".format(
+                    color.dye_out(p.citekey, 'citekey')
+                )
+            )
+            continue
         ui.info('{} imported.'.format(color.dye_out(p.citekey, 'citekey')))
         docfile = bibstruct.extract_docfile(p.bibdata)
         if docfile is None:

--- a/tests/str_fixtures.py
+++ b/tests/str_fixtures.py
@@ -17,6 +17,22 @@ institution = {Stanford InfoLab},
 }
 """
 
+bibtex_external_alt = """
+@techreport{Page99,
+     number = {1999-66},
+      month = {November},
+     author = {Lawrence Page and Sergey Brin and Rajeev Motwani and Terry Winograd},
+       note = {Previous number = SIDL-WP-1999-0120},
+      title = {The PageRank Citation Ranking: Bringing Order to the Web.},
+       type = {Technical Report},
+  publisher = {Stanford InfoLab},
+       year = {9999},
+institution = {Stanford InfoLab},
+        url = {http://ilpubs.stanford.edu:8090/422/},
+   abstract = "This is not a real entry, it is just here to test overwriting fails on import. it must have a different year than the str_fixture bibtex_external0, but must have the same citekey for the test to be valid.",
+}
+"""
+
 bibtex_raw0 = """@techreport{
     Page99,
     author = "Page, Lawrence and Brin, Sergey and Motwani, Rajeev and Winograd, Terry",

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -884,14 +884,18 @@ class TestUsecase(DataCommandTestCase):
         self.assertEqual(1 + 1, len(outs[-1].split('\n')))
 
     def test_import_does_not_overwrite(self):
+        with FakeFileOpen(self.fs)('data/real.bib', 'w') as f:
+            f.write(str_fixtures.bibtex_external0)
+        with FakeFileOpen(self.fs)('data/fake.bib', 'w') as f:
+            f.write(str_fixtures.bibtex_external_alt)
         cmds = ['pubs init',
-                'pubs import data/ Page99',
-                'pubs import data/',
+                'pubs import data/real.bib Page99',
+                'pubs import data/fake.bib Page99',
                 'pubs list'
                ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual("(1999)", outs[-1][-8:].strip())
 
-        with self.assertRaises(FakeSystemExit):
-            self.execute_cmds(cmds)
 
     def test_import_overwrites(self):
         cmds = ['pubs init',

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -811,7 +811,7 @@ class TestUsecase(DataCommandTestCase):
 
     def test_edit(self):
         bib = str_fixtures.bibtex_external0
-        bib1 = re.sub('year = \{1999\}', 'year = {2007}', bib)
+        bib1 = re.sub(r'year = \{1999\}', 'year = {2007}', bib)
         bib2 = re.sub('Lawrence Page', 'Lawrence Ridge', bib1)
         bib3 = re.sub('Page99', 'Ridge07', bib2)
 
@@ -890,11 +890,12 @@ class TestUsecase(DataCommandTestCase):
             f.write(str_fixtures.bibtex_external_alt)
         cmds = ['pubs init',
                 'pubs import data/real.bib Page99',
+                'pubs list',
                 'pubs import data/fake.bib Page99',
-                'pubs list'
+                'pubs list',
                ]
         outs = self.execute_cmds(cmds)
-        self.assertEqual("(1999)", outs[-1][-8:].strip())
+        self.assertEqual(outs[-3], outs[-1])
 
 
     def test_import_overwrites(self):
@@ -1098,7 +1099,7 @@ class TestCache(DataCommandTestCase):
         DataCommandTestCase.setUp(self, nsec_stat=nsec_stat)
 
         bib = str_fixtures.bibtex_external0
-        bib1 = re.sub('year = \{1999\}', 'year = {2007}', bib)
+        bib1 = re.sub(r'year = \{1999\}', 'year = {2007}', bib)
 
         line = '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) \n'
         line1 = re.sub('1999', '2007', line)


### PR DESCRIPTION
Citekeys that were already in the repo failed and halted execution.
This means that what to me seems like a common case of importing a `.bib`
file that contains both previously entered and new entries would fail or require
`-O` (which would overwrite)

I had tried `--ignore-malformed` to make sure that didn't handle this case, but it still failed.