### PR TITLE
adds chronological listing using bibtex year field

### DIFF
--- a/pubs/commands/list_cmd.py
+++ b/pubs/commands/list_cmd.py
@@ -48,8 +48,8 @@ def command(conf, args):
         papers = [p for p in papers if p.docpath is None]
     if args.alphabetical:
         papers = sorted(papers, key=lambda p: p.citekey)
-    if args.chronological:
-        papers = sorted(papers, key=lambda p: p.bibdata['year'])
+    elif args.chronological:
+        papers = sorted(papers, key=lambda p: ('year' not in p.bibdata, p.bibdata.get('year'), p.bibdata.get('month'), date_added))
     else:
         papers = sorted(papers, key=date_added)
     if len(papers) > 0:

--- a/pubs/commands/list_cmd.py
+++ b/pubs/commands/list_cmd.py
@@ -49,7 +49,7 @@ def command(conf, args):
     if args.alphabetical:
         papers = sorted(papers, key=lambda p: p.citekey)
     elif args.chronological:
-        papers = sorted(papers, key=lambda p: ('year' not in p.bibdata, p.bibdata.get('year'), p.bibdata.get('month'), date_added))
+        papers = sorted(papers, key=lambda p: ('year' not in p.bibdata, p.bibdata.get('year'), date_added))
     else:
         papers = sorted(papers, key=date_added)
     if len(papers) > 0:

--- a/pubs/commands/list_cmd.py
+++ b/pubs/commands/list_cmd.py
@@ -22,6 +22,9 @@ def parser(subparsers, conf):
     parser.add_argument('-a', '--alphabetical', action='store_true',
                         dest='alphabetical', default=False,
                         help='lexicographic order on the citekeys.')
+    parser.add_argument('-C', '--chronological', action='store_true',
+                        dest='chronological', default=False,
+                        help='chronological order on the year field.')
     parser.add_argument('--no-docs', action='store_true',
                         dest='nodocs', default=False,
                         help='list only pubs without attached documents.')
@@ -45,6 +48,8 @@ def command(conf, args):
         papers = [p for p in papers if p.docpath is None]
     if args.alphabetical:
         papers = sorted(papers, key=lambda p: p.citekey)
+    if args.chronological:
+        papers = sorted(papers, key=lambda p: p.bibdata['year'])
     else:
         papers = sorted(papers, key=date_added)
     if len(papers) > 0:

--- a/tests/bibexamples/noyear.bib
+++ b/tests/bibexamples/noyear.bib
@@ -1,0 +1,5 @@
+@article{Doe_noyear,
+  title={About Assigning Timestamps to Research Articles},
+  author={Doe, John},
+  journal={Journal Example},
+}

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -516,6 +516,28 @@ class TestList(DataCommandTestCase):
         self.assertEqual(0, len(outs[3].splitlines()))
         self.assertEqual(1, len(outs[4].splitlines()))
 
+    def test_list_chronological_order(self):
+        cmds = ['pubs init',
+                'pubs import data/',
+                'pubs list --chronological',
+                'pubs import bibexamples/noyear.bib',
+                'pubs list -C',
+
+                ]
+        data_chrono_correct = '[Einstein_1935] Einstein, A. et al. "Can Quantum-Mechanical Description of Physical Reality Be Considered Complete?" Physical Review (1935) \n' \
+                   '[Schrodinger_1935] Schrödinger, E. and Born, M. "Discussion of Probability Relations between Separated Systems" Mathematical Proceedings of the Cambridge Philosophical Society (1935) \n' \
+                   '[turing1950computing] Turing, Alan M "Computing machinery and intelligence" Mind (1950) \n' \
+                   '[Bell_1964] Bell, J. S. "On the Einstein Podolsky Rosen paradox" Physics Physique физика (1964) \n' \
+                   '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) \n' \
+                   '[10.1371_journal.pone.0038236] Saunders, Caroline Lyon AND Chrystopher L. Nehaniv AND Joe "Interactive Language Learning by Robots: The Transition from Babbling to Word Forms" PLoS ONE (2012) \n' \
+                   '[10.1371_journal.pone.0063400] Ay, Georg Martius AND Ralf Der AND Nihat "Information Driven Self-Organization of Complex Robotic Behaviors" PLoS ONE (2013) \n' \
+                   '[Cesar2013] César, Jean "An amazing title" Nice Journal (2013) \n'
+        correct = [ data_chrono_correct,
+                   data_chrono_correct + '[Doe_noyear] Doe, John "About Assigning Timestamps to Research Articles" Journal Example \n'
+                   ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual(outs[2], correct[0])
+        self.assertEqual(outs[4], correct[1])
 
 class TestTag(DataCommandTestCase):
 

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -530,8 +530,8 @@ class TestList(DataCommandTestCase):
                    '[Bell_1964] Bell, J. S. "On the Einstein Podolsky Rosen paradox" Physics Physique физика (1964) \n' \
                    '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) \n' \
                    '[10.1371_journal.pone.0038236] Saunders, Caroline Lyon AND Chrystopher L. Nehaniv AND Joe "Interactive Language Learning by Robots: The Transition from Babbling to Word Forms" PLoS ONE (2012) \n' \
-                   '[10.1371_journal.pone.0063400] Ay, Georg Martius AND Ralf Der AND Nihat "Information Driven Self-Organization of Complex Robotic Behaviors" PLoS ONE (2013) \n' \
-                   '[Cesar2013] César, Jean "An amazing title" Nice Journal (2013) \n'
+                   '[Cesar2013] César, Jean "An amazing title" Nice Journal (2013) \n' \
+                   '[10.1371_journal.pone.0063400] Ay, Georg Martius AND Ralf Der AND Nihat "Information Driven Self-Organization of Complex Robotic Behaviors" PLoS ONE (2013) \n'
         correct = [ data_chrono_correct,
                    data_chrono_correct + '[Doe_noyear] Doe, John "About Assigning Timestamps to Research Articles" Journal Example \n'
                    ]

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -519,25 +519,24 @@ class TestList(DataCommandTestCase):
     def test_list_chronological_order(self):
         cmds = ['pubs init',
                 'pubs import data/',
+                'pubs remove -f Einstein_1935',
+                'pubs remove -f Cesar2013',
                 'pubs list --chronological',
                 'pubs import bibexamples/noyear.bib',
                 'pubs list -C',
-
                 ]
-        data_chrono_correct = '[Einstein_1935] Einstein, A. et al. "Can Quantum-Mechanical Description of Physical Reality Be Considered Complete?" Physical Review (1935) \n' \
-                   '[Schrodinger_1935] Schrödinger, E. and Born, M. "Discussion of Probability Relations between Separated Systems" Mathematical Proceedings of the Cambridge Philosophical Society (1935) \n' \
+        data_chrono_correct = '[Schrodinger_1935] Schrödinger, E. and Born, M. "Discussion of Probability Relations between Separated Systems" Mathematical Proceedings of the Cambridge Philosophical Society (1935) \n' \
                    '[turing1950computing] Turing, Alan M "Computing machinery and intelligence" Mind (1950) \n' \
                    '[Bell_1964] Bell, J. S. "On the Einstein Podolsky Rosen paradox" Physics Physique физика (1964) \n' \
                    '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) \n' \
                    '[10.1371_journal.pone.0038236] Saunders, Caroline Lyon AND Chrystopher L. Nehaniv AND Joe "Interactive Language Learning by Robots: The Transition from Babbling to Word Forms" PLoS ONE (2012) \n' \
-                   '[Cesar2013] César, Jean "An amazing title" Nice Journal (2013) \n' \
                    '[10.1371_journal.pone.0063400] Ay, Georg Martius AND Ralf Der AND Nihat "Information Driven Self-Organization of Complex Robotic Behaviors" PLoS ONE (2013) \n'
         correct = [ data_chrono_correct,
                    data_chrono_correct + '[Doe_noyear] Doe, John "About Assigning Timestamps to Research Articles" Journal Example \n'
                    ]
         outs = self.execute_cmds(cmds)
-        self.assertEqual(outs[2], correct[0])
-        self.assertEqual(outs[4], correct[1])
+        self.assertEqual(outs[4], correct[0])
+        self.assertEqual(outs[6], correct[1])
 
 class TestTag(DataCommandTestCase):
 


### PR DESCRIPTION
This small change adds the `-C` / `--chronological` option to the `list` command in order to output the entries based on the year of publication.