### PR TITLE
Added '-a' (--append) arg to append a line of text to the notes file.

### DIFF
--- a/pubs/commands/note_cmd.py
+++ b/pubs/commands/note_cmd.py
@@ -10,6 +10,7 @@ def parser(subparsers, conf):
                                    help='edit the note attached to a paper')
     parser.add_argument('citekey', help='citekey of the paper',
                         ).completer = CiteKeyCompletion(conf)
+    parser.add_argument('-a', '--append', help='append a line of text to the notes file', default=None)
     return parser
 
 
@@ -18,7 +19,12 @@ def command(conf, args):
     ui = get_ui()
     rp = repo.Repository(conf)
     citekey = resolve_citekey(rp, args.citekey, ui=ui, exit_on_fail=True)
+    append = args.append
     notepath = rp.databroker.real_notepath(citekey, rp.conf['main']['note_extension'])
-    ui.edit_file(notepath, temporary=False)
+    if append is None:
+        ui.edit_file(notepath, temporary=False)
+    else:
+        with open(notepath, 'a') as fd:
+            fd.write(append)
     NoteEvent(citekey).send()
     rp.close()

--- a/pubs/commands/note_cmd.py
+++ b/pubs/commands/note_cmd.py
@@ -3,6 +3,7 @@ from ..uis import get_ui
 from ..utils import resolve_citekey
 from ..completion import CiteKeyCompletion
 from ..events import NoteEvent
+from ..content import write_file
 
 
 def parser(subparsers, conf):
@@ -10,7 +11,8 @@ def parser(subparsers, conf):
                                    help='edit the note attached to a paper')
     parser.add_argument('citekey', help='citekey of the paper',
                         ).completer = CiteKeyCompletion(conf)
-    parser.add_argument('-a', '--append', help='append a line of text to the notes file', default=None)
+    parser.add_argument('-a', '--append',
+                        help='append a line of text to the notes file', default=None)
     return parser
 
 
@@ -19,12 +21,11 @@ def command(conf, args):
     ui = get_ui()
     rp = repo.Repository(conf)
     citekey = resolve_citekey(rp, args.citekey, ui=ui, exit_on_fail=True)
-    append = args.append
+    latestnote = '{TXT}\n'.format(TXT=args.append)
     notepath = rp.databroker.real_notepath(citekey, rp.conf['main']['note_extension'])
-    if append is None:
+    if latestnote is None:
         ui.edit_file(notepath, temporary=False)
     else:
-        with open(notepath, 'a') as fd:
-            fd.write(append)
+        write_file(notepath, latestnote, 'a')
     NoteEvent(citekey).send()
     rp.close()

--- a/pubs/commands/note_cmd.py
+++ b/pubs/commands/note_cmd.py
@@ -21,11 +21,11 @@ def command(conf, args):
     ui = get_ui()
     rp = repo.Repository(conf)
     citekey = resolve_citekey(rp, args.citekey, ui=ui, exit_on_fail=True)
-    latestnote = '{TXT}\n'.format(TXT=args.append)
     notepath = rp.databroker.real_notepath(citekey, rp.conf['main']['note_extension'])
-    if latestnote is None:
+    if args.append is None:
         ui.edit_file(notepath, temporary=False)
     else:
+        latestnote = '{TXT}\n'.format(TXT=args.append)
         write_file(notepath, latestnote, 'a')
     NoteEvent(citekey).send()
     rp.close()

--- a/pubs/commands/note_cmd.py
+++ b/pubs/commands/note_cmd.py
@@ -25,7 +25,7 @@ def command(conf, args):
     if args.append is None:
         ui.edit_file(notepath, temporary=False)
     else:
-        latestnote = '{TXT}\n'.format(TXT=args.append)
+        latestnote = '{txt}\n'.format(txt=args.append)
         write_file(notepath, latestnote, 'a')
     NoteEvent(citekey).send()
     rp.close()

--- a/tests/test_note_append.py
+++ b/tests/test_note_append.py
@@ -34,6 +34,11 @@ class TestNoteAppend(DataCommandTestCase):
         self.execute_cmds(cmds)
         note_lines.append('bbb')
         self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+        # Test adding Chinese characters
+        cmds = [('pubs note Page99 -a \347\350\346\345')]
+        self.execute_cmds(cmds)
+        note_lines.append('\347\350\346\345')
+        self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
         # # Test adding Japanese character
         # cmds = [('pubs note Page99 -a ソ')]
         # self.execute_cmds(cmds)
@@ -43,7 +48,7 @@ class TestNoteAppend(DataCommandTestCase):
     @staticmethod
     def _get_note_content(note_lines):
         """Given a list of note lines, return full note file content"""
-        return '{LINES}\n'.format(LINES='\n'.join(note_lines))
+        return '{lines}\n'.format(lines='\n'.join(note_lines))
 
 
 if __name__ == '__main__':

--- a/tests/test_note_append.py
+++ b/tests/test_note_append.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """Test appending a note file from the command-line using the '-a' arg"""
 
+# If you store your pubs in a directory other than home, you may want to 
+# set this prior to running this test:
+#   export PUBSCONF=~/.pubsrc
+
 from __future__ import print_function, unicode_literals
 
 import unittest
@@ -34,11 +38,20 @@ class TestNoteAppend(DataCommandTestCase):
         self.execute_cmds(cmds)
         note_lines.append('bbb')
         self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
-        # Test adding Chinese characters
-        cmds = [('pubs note Page99 -a \347\350\346\345')]
-        self.execute_cmds(cmds)
-        note_lines.append('\347\350\346\345')
-        self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+
+        # # https://github.com/pubs/pubs/pull/201#discussion_r307499310
+        # # Test multiword line
+        # cmds = [('pubs', 'note', 'Page99', '-a',  'xxx yyy',)]
+        # self.execute_cmds(cmds)
+        # note_lines.append('xxx yyy')
+        # self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+
+        # # https://github.com/pubs/pubs/pull/201#discussion_r305274071
+        # # Test adding Chinese characters
+        # cmds = [('pubs note Page99 -a \347\350\346\345')]
+        # self.execute_cmds(cmds)
+        # note_lines.append('\347\350\346\345')
+        # self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
         # # Test adding Japanese character
         # cmds = [('pubs note Page99 -a ソ')]
         # self.execute_cmds(cmds)

--- a/tests/test_note_append.py
+++ b/tests/test_note_append.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """Test appending a note file from the command-line using the '-a' arg"""
 
-# If you store your pubs in a directory other than home, you may want to 
+# If you store your pubs in a directory other than home, you may want to
 # set this prior to running this test:
 #   export PUBSCONF=~/.pubsrc
+
+# vim -p tests/test_note_append.py tests/test_usecase.py
 
 from __future__ import print_function, unicode_literals
 
@@ -39,12 +41,15 @@ class TestNoteAppend(DataCommandTestCase):
         note_lines.append('bbb')
         self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
 
-        # # https://github.com/pubs/pubs/pull/201#discussion_r307499310
-        # # Test multiword line
-        # cmds = [('pubs', 'note', 'Page99', '-a',  'xxx yyy',)]
-        # self.execute_cmds(cmds)
-        # note_lines.append('xxx yyy')
-        # self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+        # https://github.com/pubs/pubs/pull/201#discussion_r307499310
+        # Test multiword line.
+        #   * Pass the command split into a command and its args to
+        #     execute_cmdsplit, which is called by execute_cmds:
+        #cmds = [('pubs note Page99 -a "xxx yyy"')]
+        cmd_split = ['pubs', 'note', 'Page99', '-a', 'xxx yyy']
+        self.execute_cmdsplit(cmd_split, expected_out=None, expected_err=None)
+        note_lines.append('xxx yyy')
+        self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
 
         # # https://github.com/pubs/pubs/pull/201#discussion_r305274071
         # # Test adding Chinese characters

--- a/tests/test_note_append.py
+++ b/tests/test_note_append.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Test appending a note file from the command-line using the '-a' arg"""
+
+from __future__ import print_function, unicode_literals
+
+import unittest
+import os
+
+from tests.test_usecase import DataCommandTestCase
+
+
+class TestNoteAppend(DataCommandTestCase):
+    """Test appending a note file from the command-line using the '-a' arg"""
+
+    def setUp(self, nsec_stat=True):
+        """Initialize a bib entry containing citation key, Page99, for testing"""
+        super(TestNoteAppend, self).setUp()
+        init = ['pubs init',
+                'pubs add data/pagerank.bib',
+               ]
+        self.execute_cmds(init)
+        self.note_dir = os.path.join(self.default_pubs_dir, 'notes')
+
+    def test_note_edit(self):
+        """Test appending the note file using the command-line argument, -a"""
+        fin_notes = os.path.join(self.note_dir, 'Page99.txt')
+        # Test adding first line
+        cmds = [('pubs note Page99 -a aaa')]
+        self.execute_cmds(cmds)
+        note_lines = ['aaa']
+        self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+        # Test adding additional line
+        cmds = [('pubs note Page99 -a bbb')]
+        self.execute_cmds(cmds)
+        note_lines.append('bbb')
+        self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+        # Test adding Japanese character
+        cmds = [('pubs note Page99 -a ソ')]
+        self.execute_cmds(cmds)
+        note_lines.append('ソ')
+        self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+
+    @staticmethod
+    def _get_note_content(note_lines):
+        """Given a list of note lines, return full note file content"""
+        return '{LINES}\n'.format(LINES='\n'.join(note_lines))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_note_append.py
+++ b/tests/test_note_append.py
@@ -21,7 +21,7 @@ class TestNoteAppend(DataCommandTestCase):
         self.execute_cmds(init)
         self.note_dir = os.path.join(self.default_pubs_dir, 'notes')
 
-    def test_note_edit(self):
+    def test_note_append(self):
         """Test appending the note file using the command-line argument, -a"""
         fin_notes = os.path.join(self.note_dir, 'Page99.txt')
         # Test adding first line
@@ -34,11 +34,11 @@ class TestNoteAppend(DataCommandTestCase):
         self.execute_cmds(cmds)
         note_lines.append('bbb')
         self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
-        # Test adding Japanese character
-        cmds = [('pubs note Page99 -a ソ')]
-        self.execute_cmds(cmds)
-        note_lines.append('ソ')
-        self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
+        # # Test adding Japanese character
+        # cmds = [('pubs note Page99 -a ソ')]
+        # self.execute_cmds(cmds)
+        # note_lines.append('ソ')
+        # self.assertFileContentEqual(fin_notes, self._get_note_content(note_lines))
 
     @staticmethod
     def _get_note_content(note_lines):


### PR DESCRIPTION
Please consider this pull request, which augments the 'pubs note' command so text can be appended to the note file without needed to open the file in an editor, write it, then close it.