### PR TITLE
`conf` not defined in `resolve_citekey`, use `self.conf`

### DIFF
--- a/pubs/utils.py
+++ b/pubs/utils.py
@@ -33,7 +33,7 @@ def resolve_citekey(repo, citekey, ui=None, exit_on_fail=True):
                      "citekeys:".format(citekey))
             for c in citekeys:
                 p = repo.pull_paper(c)
-                ui.message('    {}'.format(pretty.paper_oneliner(p, max_authors=conf['main']['max_authors'])))
+                ui.message('    {}'.format(pretty.paper_oneliner(p, max_authors=self.conf['main']['max_authors'])))
             if exit_on_fail:
                 ui.exit()
     return citekey


### PR DESCRIPTION
With ambiguous citekeys, the following error occurred:

```
$ pubs edit Li
error: Be more specific; 'Li' matches multiples citekeys:
error: name 'conf' is not defined
Traceback (most recent call last):
  File "/usr/bin/pubs", line 11, in <module>
    load_entry_point('pubs==0.8.3', 'console_scripts', 'pubs')()
  File "/usr/lib/python3.8/site-packages/pubs/pubs_cmd.py", line 107, in execute
    if not uis.get_ui().handle_exception(e):
  File "/usr/lib/python3.8/site-packages/pubs/pubs_cmd.py", line 104, in execute
    args.func(conf, args)
  File "/usr/lib/python3.8/site-packages/pubs/commands/edit_cmd.py", line 33, in command
    citekey = resolve_citekey(rp, args.citekey, ui=ui, exit_on_fail=True)
  File "/usr/lib/python3.8/site-packages/pubs/utils.py", line 36, in resolve_citekey
    ui.message('    {}'.format(pretty.paper_oneliner(p, max_authors=conf['main']['max_authors'])))
NameError: name 'conf' is not defined
```

`resolve_citekey` should access `self.conf`, as no `conf` parameter is
given.