### PR TITLE
fix missing conf argument for resolve_citekey

### DIFF
--- a/pubs/commands/doc_cmd.py
+++ b/pubs/commands/doc_cmd.py
@@ -71,7 +71,7 @@ def command(conf, args):
     # ui.exit()
 
     if args.action == 'add':
-        citekey = resolve_citekey(rp, args.citekey[0], ui=ui, exit_on_fail=True)
+        citekey = resolve_citekey(rp, conf, args.citekey[0], ui=ui, exit_on_fail=True)
         paper = rp.pull_paper(citekey)
 
         if paper.docpath is not None and not args.force:
@@ -98,7 +98,7 @@ def command(conf, args):
 
     elif args.action == 'remove':
 
-        for key in resolve_citekey_list(rp, args.citekeys, ui=ui, exit_on_fail=True):
+        for key in resolve_citekey_list(rp, conf, args.citekeys, ui=ui, exit_on_fail=True):
             paper = rp.pull_paper(key)
 
             # if there is no document (and the user cares) -> inform + continue
@@ -126,7 +126,7 @@ def command(conf, args):
                 color.dye_err(args.path[0], 'filepath')))
             ui.exit(1)
 
-        for key in resolve_citekey_list(rp, args.citekeys, ui=ui, exit_on_fail=True):
+        for key in resolve_citekey_list(rp, conf, args.citekeys, ui=ui, exit_on_fail=True):
             try:
                 paper = rp.pull_paper(key)
                 doc = paper.docpath
@@ -143,7 +143,7 @@ def command(conf, args):
 
     elif args.action == 'open':
         with_command = args.cmd
-        citekey = resolve_citekey(rp, args.citekey[0], ui=ui, exit_on_fail=True)
+        citekey = resolve_citekey(rp, conf, args.citekey[0], ui=ui, exit_on_fail=True)
         paper = rp.pull_paper(citekey)
 
         if paper.docpath is None:

--- a/pubs/commands/edit_cmd.py
+++ b/pubs/commands/edit_cmd.py
@@ -30,7 +30,7 @@ def command(conf, args):
     meta = args.meta
 
     rp = repo.Repository(conf)
-    citekey = resolve_citekey(rp, args.citekey, ui=ui, exit_on_fail=True)
+    citekey = resolve_citekey(rp, conf, args.citekey, ui=ui, exit_on_fail=True)
     paper = rp.pull_paper(citekey)
 
     coder = EnDecoder()

--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -46,7 +46,7 @@ def command(conf, args):
     if len(args.citekeys) < 1:
         papers = rp.all_papers()
     else:
-        for key in resolve_citekey_list(repo=rp, citekeys=args.citekeys, ui=ui, exit_on_fail=True):
+        for key in resolve_citekey_list(rp, conf, args.citekeys, ui=ui, exit_on_fail=True):
             papers.append(rp.pull_paper(key))
 
     bib = {}

--- a/pubs/commands/note_cmd.py
+++ b/pubs/commands/note_cmd.py
@@ -23,7 +23,7 @@ def command(conf, args):
 
     ui = get_ui()
     rp = repo.Repository(conf)
-    citekey = resolve_citekey(rp, args.citekey, ui=ui, exit_on_fail=True)
+    citekey = resolve_citekey(rp, conf, args.citekey, ui=ui, exit_on_fail=True)
     notepath = rp.databroker.real_notepath(citekey, rp.conf['main']['note_extension'])
     if args.append is None:
         ui.edit_file(notepath, temporary=False)

--- a/pubs/commands/remove_cmd.py
+++ b/pubs/commands/remove_cmd.py
@@ -24,7 +24,7 @@ def command(conf, args):
     force = args.force
     rp = repo.Repository(conf)
 
-    keys = resolve_citekey_list(repo=rp, citekeys=args.citekeys, ui=ui, exit_on_fail=True)
+    keys = resolve_citekey_list(rp, conf, args.citekeys, ui=ui, exit_on_fail=True)
 
     if force is None:
         are_you_sure = (("Are you sure you want to delete the publication(s) [{}]"

--- a/pubs/commands/rename_cmd.py
+++ b/pubs/commands/rename_cmd.py
@@ -26,7 +26,7 @@ def command(conf, args):
     rp = repo.Repository(conf)
 
     # TODO: here should be a test whether the new citekey is valid
-    key = resolve_citekey(repo=rp, citekey=args.citekey, ui=ui, exit_on_fail=True)
+    key = resolve_citekey(rp, conf, args.citekey, ui=ui, exit_on_fail=True)
     paper = rp.pull_paper(key)
     rp.rename_paper(paper, args.new_citekey)
     ui.message("The '{}' citekey has been renamed into '{}'".format(

--- a/pubs/commands/tag_cmd.py
+++ b/pubs/commands/tag_cmd.py
@@ -89,7 +89,7 @@ def command(conf, args):
     else:
         not_citekey = False
         try:
-            citekeyOrTag = resolve_citekey(repo=rp, citekey=citekeyOrTag, ui=ui, exit_on_fail=True)
+            citekeyOrTag = resolve_citekey(rp, conf, citekeyOrTag, ui=ui, exit_on_fail=True)
         except SystemExit:
             not_citekey = True
         if not not_citekey:

--- a/pubs/commands/url_cmd.py
+++ b/pubs/commands/url_cmd.py
@@ -22,7 +22,7 @@ def command(conf, args):
     ui = get_ui()
     rp = repo.Repository(conf)
 
-    for key in resolve_citekey_list(rp, args.citekey, ui=ui, exit_on_fail=False):
+    for key in resolve_citekey_list(rp, conf, args.citekey, ui=ui, exit_on_fail=False):
         try:
             paper = rp.pull_paper(key)
             url = paper.bibdata['url']

--- a/pubs/utils.py
+++ b/pubs/utils.py
@@ -7,7 +7,7 @@ from . import color
 from . import pretty
 
 
-def resolve_citekey(repo, citekey, ui=None, exit_on_fail=True):
+def resolve_citekey(repo, conf, citekey, ui=None, exit_on_fail=True):
     """Check that a citekey exists, or autocompletes it if not ambiguous.
         :returns found citekey
     """
@@ -39,12 +39,12 @@ def resolve_citekey(repo, citekey, ui=None, exit_on_fail=True):
     return citekey
 
 
-def resolve_citekey_list(repo, citekeys, ui=None, exit_on_fail=True):
+def resolve_citekey_list(repo, conf, citekeys, ui=None, exit_on_fail=True):
     shutdown = False
     keys = []
     for key in citekeys:
         try:
-            keys.append(resolve_citekey(repo, key, ui, exit_on_fail))
+            keys.append(resolve_citekey(repo, conf, key, ui=ui, exit_on_fail=exit_on_fail))
         except SystemExit:
             shutdown = exit_on_fail
 


### PR DESCRIPTION
Proper PR instead of #231 .

There is some strange behaviour coming from `ui.error`, though (at least with python `3.8.3`):

The error message `error: Be more specific; 'citekey' matches multiples citekeys:`

appears **after** the list of publications which match the citekey and comes last. This should not be the case, as `ui.error` is called before listing the publications (and indeed, any other `print` command in `ui.error` actually gets executed).

The problem lies with https://github.com/pubs/pubs/blob/master/pubs/uis.py#L88. If `**kwargs` is removed from the `print` statement, the sequence is preserved.