### PR TITLE
Add note on using commas in alias descriptions

### DIFF
--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -99,6 +99,11 @@ active = force_list(default=list('alias'))
 # command = !pubs list -k | wc -l
 # description = lists number of pubs in repo
 
+# To use commas in the description, wrap them in a "" string. For example:
+# [[[hellocount]]]
+# command = !pubs list -k | wc -l; echo "hello!"
+# description = "lists number of pubs in repo, greets the user afterward"
+
 [[git]]
 # The git plugin will commit changes to the repository in a git repository
 # created at the root of the pubs directory. All detected changes will be

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -100,8 +100,6 @@ active = force_list(default=list('alias'))
 # description = lists number of pubs in repo
 
 # To use commas in the description, wrap them in a "" string. For example:
-# [[[hellocount]]]
-# command = !pubs list -k | wc -l; echo "hello!"
 # description = "lists number of pubs in repo, greets the user afterward"
 
 [[git]]


### PR DESCRIPTION
On my installation, using commas in docstring descriptions causes a `error: unsupported operand type(s) for %: 'list' and 'dict'` error. Wrapping the description in a string solves that.