### PR TITLE
Allow passing named arguments to custom commands (alias).

### DIFF
--- a/pubs/plugs/alias/alias.py
+++ b/pubs/plugs/alias/alias.py
@@ -1,5 +1,6 @@
 import shlex
 import subprocess
+import argparse
 from pipes import quote as shell_quote
 
 from ...plugins import PapersPlugin
@@ -19,7 +20,7 @@ class Alias(object):
     def parser(self, parser):
         self.parser = parser
         p = parser.add_parser(self.name, help=self.description)
-        p.add_argument('arguments', nargs='*',
+        p.add_argument('arguments', nargs=argparse.REMAINDER,
                        help="arguments to be passed to %s" % self.name)
         return p
 

--- a/tests/test_plug_alias.py
+++ b/tests/test_plug_alias.py
@@ -1,7 +1,7 @@
 import shlex
 import unittest
-
 import dotdot
+import argparse
 
 import pubs
 from pubs import config
@@ -60,6 +60,19 @@ class AliasTestCase(unittest.TestCase):
         self.assertEqual(
             shlex.split(self.subprocess.called.splitlines()[-1])[1:],
             args)
+
+    def testShellAliasNamedArguments(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--test2')
+        subparsers = parser.add_subparsers(title='commands', dest='command')
+
+        alias = Alias.create_alias('test', '!echo "$@"')
+        alias.parser(subparsers)
+        args = ['test', '2', '--option', '3']
+        args = parser.parse_args(args)
+
+        self.assertEqual(args.command, 'test')
+        self.assertListEqual(args.arguments, ['2', '--option', '3'])
 
 
 class AliasPluginTestCase(unittest.TestCase):


### PR DESCRIPTION
This allows passing named arguments to custom commands. An example would be `pubs search keyword --ignore-author` and the corresponding alias would redirect the call to the custom script like follows: `search = !"$DOTFILES/pubs/scripts/search.py" "$@"`.