### PR TITLE
Have the option to disable git init for the repo

### DIFF
--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -110,6 +110,9 @@ active = force_list(default=list('alias'))
 # limitation of the subcommand is that you cannot use git commands with the
 # `-c` option (pubs will interpret it first.)
 
+# if true, pubs will initialize a git repo in pubsdir if there is not .git
+# folder present. if false, git plugin will assume we are in a git repo.
+repo_init = boolean(default=True)
 # if False, will display git output when automatic commit are made.
 # Invocation of `pubs git` will always have output displayed.
 quiet = boolean(default=True)

--- a/pubs/plugs/git/git.py
+++ b/pubs/plugs/git/git.py
@@ -32,6 +32,7 @@ class GitPlugin(PapersPlugin):
         self.manual      = conf['plugins'].get('git', {}).get('manual', False)
         self.force_color = conf['plugins'].get('git', {}).get('force_color', True)
         self.quiet   = conf['plugins'].get('git', {}).get('quiet', True)
+        self.repo_init = conf['plugins'].get('git', {}).get('repo_init', True)
         self.list_of_changes = []
         self._gitinit()
 
@@ -39,7 +40,7 @@ class GitPlugin(PapersPlugin):
         """Initialize the git repository if necessary."""
         # check that a `.git` directory is present in the pubs dir
         git_path = os.path.join(self.pubsdir, '.git')
-        if not os.path.isdir(git_path):
+        if not os.path.isdir(git_path) and self.repo_init:
             try:
                 self.shell('init')
             except RuntimeError as exc:


### PR DESCRIPTION
Figured other people would like this toggle since there may be use cases where the pubsdir is not the root of the repo (in my case, it isn't now). I'll try to see if I can add tests for it sometime soon, but its a pretty straightforward PR so you guys can review it first while I get that up :)