### PR TITLE
Add pytest to test requirements as none optional.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ matrix:
     # Mock tests (with mock API)
     - os: linux
       language: python
-      python: 3.5
-      env:
-        - TO_TEST=TEST_MOCK
-    - os: linux
-      language: python
       python: 3.6
       env:
         - TO_TEST=TEST_MOCK

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     # Full tests (with online API)
     - os: linux
       language: python
-      python: 3.7
+      python: 3.9
       dist: xenial
       sudo: true
       env:
@@ -40,6 +40,13 @@ matrix:
       sudo: true
       env:
         - TO_TEST=TEST_MOCK
+    - os: linux
+      language: python
+      dist: xenial
+      python: 3.9
+      sudo: true
+      env:
+        - TO_TEST=TEST_MOCK
 
 
     # Install tests
@@ -53,7 +60,7 @@ matrix:
       language: python
       dist: xenial
       sudo: true
-      python: 3.8
+      python: 3.9
       env:
         - TO_TEST=INSTALL
       if: type = cron

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -24,4 +24,4 @@ certifi
 #        (also remove in setup.py)
 ddt==1.3.1
 mock
-pytest # optional (python setup.py test works without it), but possible nonetheless
+pytest

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     ],
 
     test_suite='tests',
-    tests_require=['pyfakefs>=3.4', 'mock', 'ddt==1.3.1', 'certifi'],
+    tests_require=['pyfakefs>=3.4', 'mock', 'ddt==1.3.1', 'certifi', 'pytest'],
 
     # in order to avoid 'zipimport.ZipImportError: bad local file header'
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -45,16 +45,15 @@ setup(
         },
 
     include_package_data=True,
-
     install_requires=['pyyaml', 'bibtexparser>=1.0', 'python-dateutil', 'six',
                       'requests', 'configobj', 'beautifulsoup4', 'feedparser'],
     extras_require={'autocompletion': ['argcomplete'],
                     },
 
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Despite being marked as optional in `dev_requirements.txt`, `pytest` is needed (imported from `test_usecase.py`) which makes the build fail (see for example one of the latest master https://travis-ci.org/github/pubs/pubs/jobs/742159983).

Furthermore, Python 3.5 is not incompatible with the `feedparser` dependency (see failed build https://travis-ci.org/github/pubs/pubs/jobs/742159984); hence dropping the dependency.

Finally, adding Python 3.9 to the build matrix.