### PR TITLE
preserve case of field 'type'

### DIFF
--- a/pubs/endecoder.py
+++ b/pubs/endecoder.py
@@ -51,7 +51,6 @@ def customizations(record):
     """
 
     # record = bp.customization.convert_to_unicode(record) # transform \& into & ones, messing-up latex
-    record = bp.customization.type(record)
     record = bp.customization.author(record)
     record = bp.customization.editor(record)
     record = bp.customization.keyword(record)

--- a/tests/test_endecoder.py
+++ b/tests/test_endecoder.py
@@ -61,7 +61,7 @@ class TestEnDecode(unittest.TestCase):
         """Test that multiple encode/decode step preserve data"""
         decoder = endecoder.EnDecoder()
         entry = decoder.decode_bibdata(bibtex_raw0)
-        self.assertEqual(entry['Page99']['type'], "technical report")
+        self.assertEqual(entry['Page99']['type'], "Technical Report")
 
     def test_endecode_bibtex_BOM(self):
         """Test that bibtexparser if fine with BOM-prefixed data"""


### PR DESCRIPTION
Non-standard types such as "Diplomarbeit" should not be converted to lowercase. See e.g. https://github.com/jgm/pandoc-citeproc/issues/98.