### PR TITLE
Feat/import from pubs

### DIFF
--- a/pubs/repo.py
+++ b/pubs/repo.py
@@ -182,7 +182,6 @@ class Repository(object):
             events.RenameEvent(paper, old_citekey).send()
             return True
 
-
     def push_doc(self, citekey, docfile, copy=None):
         p = self.pull_paper(citekey)
         return self.push_doc_paper(p, docfile, copy=copy)

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -1208,6 +1208,29 @@ class TestConfigChange(DataCommandTestCase):
             self.execute_cmds([('pubs list', None, line_full, None)])
 
 
+class TestImport(DataCommandTestCase):
+
+    def test_import_list_only(self):
+        cmds = ['pubs init',
+                'pubs list',
+                'pubs import --list-only data/',
+                'pubs list title:language author:Saunders',
+                ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual(0, len(outs[1].splitlines()))
+        self.assertEqual(8, len(outs[2].splitlines()))
+        self.assertEqual(0, len(outs[3].splitlines()))
+
+    def test_import_imports(self):
+        cmds = ['pubs init',
+                'pubs list',
+                'pubs import data/',
+                'pubs list',
+                ]
+        outs = self.execute_cmds(cmds)
+        self.assertEqual(0, len(outs[1].splitlines()))
+        self.assertEqual(8, len(outs[3].splitlines()))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Basic import from pubs repository.

- adds a `--list-only` option to the `import` command to allow dry-run before importing,
- adds explicit import modes (`pubs` or `bibtex`), and basic guess on implicit,
- adds basic import mechanism form existing pubs repo,

Still to be done
- [ ] allow import from `pubsrc` config rather than directory,
- [ ] add documentation to readme,
- [ ] add note in changelog.