### PR TITLE
New features: show and search (and enhanced tag display)

### DIFF
--- a/pubs/commands/__init__.py
+++ b/pubs/commands/__init__.py
@@ -8,6 +8,8 @@ from . import remove_cmd
 from . import list_cmd
 from . import edit_cmd
 from . import tag_cmd
+from . import search_cmd
+from . import show_cmd
 from . import statistics_cmd
 # doc
 from . import doc_cmd

--- a/pubs/commands/import_cmd.py
+++ b/pubs/commands/import_cmd.py
@@ -21,7 +21,7 @@ _IGNORING_MSG = " Ignoring it."
 def parser(subparsers, conf):
     parser = subparsers.add_parser(
         'import',
-        help='import paper(s) to the repository.')
+        help='import paper(s) to the repository')
     parser.add_argument(
         'bibpath',
         help=("path to bibtex, bibtexml or bibyaml file, or a directory "

--- a/pubs/commands/search_cmd.py
+++ b/pubs/commands/search_cmd.py
@@ -1,0 +1,60 @@
+from __future__ import unicode_literals
+
+from ..paper import Paper
+from .. import repo
+from .. import color
+
+from ..uis import get_ui
+from ..endecoder import EnDecoder
+from ..utils import resolve_citekey
+from ..completion import CiteKeyCompletion
+from ..events import ModifyEvent
+
+from .show_cmd import show
+from .. import pretty
+from .. import bibstruct
+
+def parser(subparsers, conf):
+    parser = subparsers.add_parser(
+        'search',
+        help='search papers in the repository from an author or with given keywords in the title')
+    parser.add_argument(
+        '-a', '--author', default=False,
+        help='search with the author name')
+    parser.add_argument(
+        '-t', '--title', default=False,
+        help='search with the keywords in the title')
+    return parser
+
+
+def command(conf, args):
+    ui = get_ui()
+    rp = repo.Repository(conf)
+    target_author = args.author
+    keywords = args.title
+    papers = list(rp.all_papers())
+    
+    if target_author:
+        target_author = target_author.lower()
+        if keywords:
+            keywords = keywords.lower()
+            for paper in papers:
+                if paper.bibdata and 'author' in paper.bibdata and paper.bibdata['author'] and 'title' in paper.bibdata and paper.bibdata['title']:
+                    for author in paper.bibdata['author']:
+                        if target_author in author.lower() and keywords in paper.bibdata['title'].lower():
+                            show(ui, conf, paper)
+                            print()
+        else:
+            for paper in papers:
+                if paper.bibdata and 'author' in paper.bibdata and paper.bibdata['author']:
+                    for author in paper.bibdata['author']:
+                        if target_author in author.lower():
+                            show(ui, conf, paper)
+                            print()
+    else:                    
+        if keywords:
+            keywords = keywords.lower()
+            for paper in papers:
+                if paper.bibdata and 'title' in paper.bibdata and paper.bibdata['title'] and keywords in paper.bibdata['title'].lower():
+                    show(ui, conf, paper)
+                    print()

--- a/pubs/commands/show_cmd.py
+++ b/pubs/commands/show_cmd.py
@@ -1,0 +1,33 @@
+from __future__ import unicode_literals
+
+from .. import repo
+from .. import color
+
+from ..uis import get_ui
+from ..endecoder import EnDecoder
+from ..utils import resolve_citekey
+from ..completion import CiteKeyCompletion
+from ..events import ModifyEvent
+from .. import paper
+from .. import pretty
+
+
+def parser(subparsers, conf):
+    parser = subparsers.add_parser(
+        'show',
+        help='print a bibliographic entry on the terminal')
+    parser.add_argument(
+        'citekey',
+        help='citekey of the paper').completer = CiteKeyCompletion(conf)
+    return parser
+
+def show(ui, conf, paper):
+    ui.message('{}'.format(pretty.paper_oneliner(paper, max_authors=conf['main']['max_authors'])))
+
+def command(conf, args):
+    ui = get_ui()
+    rp = repo.Repository(conf)
+    citekey = resolve_citekey(rp, conf, args.citekey, ui=ui, exit_on_fail=True)
+    paper = rp.pull_paper(citekey)
+    show(ui, conf, paper)
+    #ui.message('{}'.format(pretty.paper_oneliner(paper, max_authors=conf['main']['max_authors'])))

--- a/pubs/commands/statistics_cmd.py
+++ b/pubs/commands/statistics_cmd.py
@@ -6,7 +6,7 @@ from .. import color
 def parser(subparsers, conf):
     parser = subparsers.add_parser(
         'statistics',
-        help="show statistics on the repository.")
+        help="show statistics on the repository")
     return parser
 
 

--- a/pubs/commands/tag_cmd.py
+++ b/pubs/commands/tag_cmd.py
@@ -87,7 +87,7 @@ def command(conf, args):
     rp = Repository(conf)
 
     if citekeyOrTag is None:
-        ui.message(color.dye_out(' '.join(sorted(rp.get_tags())), 'tag'))
+        ui.message(', '.join(color.dye_out(t, 'tag') for t in sorted(rp.get_tags())))
     else:
         not_citekey = False
         try:
@@ -97,7 +97,7 @@ def command(conf, args):
         if not not_citekey:
             p = rp.pull_paper(citekeyOrTag)
             if tags is None:
-                ui.message(color.dye_out(' '.join(sorted(p.tags)), 'tag'))
+                ui.message(', '.join(color.dye_out(t, 'tag') for t in sorted(p.tags)))
             else:
                 add_tags, remove_tags = _tag_groups(_parse_tag_seq(tags))
                 for tag in add_tags:

--- a/pubs/pretty.py
+++ b/pubs/pretty.py
@@ -78,7 +78,7 @@ def paper_oneliner(p, citekey_only=False, max_authors=3):
                                else 'NOEXT'),
                 'tag')
         tags = '' if len(p.tags) == 0 else '| {}'.format(
-            ','.join(color.dye_out(t, 'tag') for t in sorted(p.tags)))
+            ', '.join(color.dye_out(t, 'tag') for t in sorted(p.tags)))
         return '[{citekey}] {descr}{doc} {tags}'.format(
             citekey=color.dye_out(p.citekey, 'citekey'),
             descr=bibdesc, tags=tags, doc=doc_str)

--- a/pubs/pubs_cmd.py
+++ b/pubs/pubs_cmd.py
@@ -25,6 +25,8 @@ CORE_CMDS = collections.OrderedDict([
     ('list', commands.list_cmd),
     ('edit', commands.edit_cmd),
     ('tag', commands.tag_cmd),
+    ('search', commands.search_cmd),
+    ('show', commands.show_cmd),
     ('statistics', commands.statistics_cmd),
 
     ('doc', commands.doc_cmd),

--- a/readme.md
+++ b/readme.md
@@ -187,3 +187,4 @@ You can access the self-documented configuration by using `pubs conf`, and all t
 - [Jonáš Kulhánek](https://github.com/jkulhanek)
 - [Dominik Stańczak](https://github.com/StanczakDominik)
 - [Gustavo José de Sousa](https://github.com/guludo)
+- [Florian Richoux](https://github.com/richoux)

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -590,7 +590,7 @@ class TestTag(DataCommandTestCase):
                 'pubs list',
                 ]
         correct = ['',
-                   '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) | network,search\n' +
+                   '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) | network, search\n' +
                    '[Turing1950] Turing, Alan M "Computing machinery and intelligence" Mind (1950) \n',
                    ]
         out = self.execute_cmds(cmds)
@@ -738,9 +738,9 @@ class TestUsecase(DataCommandTestCase):
                    '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) [pdf] \n',
                    '\n',
                    '',
-                   'network search\n',
+                   'network, search\n',
                    'info: Assuming search to be a tag.\n'
-                   '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) [pdf] | network,search\n',
+                   '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) [pdf] | network, search\n',
                   ]
 
         cmds = ['pubs init -p /paper_first',
@@ -785,7 +785,7 @@ class TestUsecase(DataCommandTestCase):
                    '',
                    '',
                    '',
-                   'search network\n',
+                   'search, network\n',
                   ]
 
         cmds = ['pubs init -p paper_first/',
@@ -798,7 +798,7 @@ class TestUsecase(DataCommandTestCase):
         out = self.execute_cmds(cmds)
 
         def clean(s):
-            return set(s.strip().split(' '))
+            return set(s.strip().split(', '))
 
         self.assertEqual(clean(correct[2]), clean(out[2]))
         self.assertEqual(clean(correct[4]), clean(out[4]))
@@ -879,7 +879,7 @@ class TestUsecase(DataCommandTestCase):
         meta = str_fixtures.turing_meta
 
         line = '[Page99] Page, Lawrence et al. "The PageRank Citation Ranking: Bringing Order to the Web." (1999) \n'
-        line1 = re.sub('\n', '| AI,computer\n', line)
+        line1 = re.sub('\n', '| AI, computer\n', line)
 
         cmds = ['pubs init',
                 'pubs add data/pagerank.bib',


### PR DESCRIPTION
Hi there,

Pubs was the right tool for me, I was very happy to found it! However, I though 2 functionalities were missing:
1. just printing on the screen an entry (giving its citekey), 
2. searching in the repo for entries, giving an author name and/or some keywords from the title.

So I added them:
`$ pubs show MyCitekey`
will print on the screen the same pretty line of information than the one printed just after adding a new entry.

`$ pubs search --author ThisDude` (or -a ThisDude)
will display all papers where ThisDude is a (co-)author

`$ pubs search --title "Look for these keywords in title"` (or -t "Look for these keywords in title")
will display all papers containing the block "Look for these keywords in title" in the title. It will not look for each keyword separately, it is more like one keyword that can be a block of words with spaces. This can be changed of course, but so far it covers my needs.

`$ pubs search -a ThisDude -t "Look for these keywords in title"`
will display all papers where ThisDude is a (co-)author and containing "Look for these keywords in title" in the title.

Search is case-insensitive, on purpose.

I also changed how tags are displayed (both with `$ pubs tag` and with `$ pubs tag MyCitekey`), adding an uncolored comma between tags. I have tags composed of two words separated by one space, so just separating tags by a space was not convenient at all.
I have updated tests so it can work with this new way of printing tags.