### PR TITLE
Option to exclude bibitex fields

### DIFF
--- a/pubs/commands/add_cmd.py
+++ b/pubs/commands/add_cmd.py
@@ -116,6 +116,12 @@ def command(conf, args):
         if bibentry is None:
             ui.error('invalid bibfile {}.'.format(bibfile))
 
+    # exclude bibtex fields if specified
+    for item in bibentry.values():
+        for field in conf['main']['bibtex_field_excludes']:
+            if field in item:
+                del item[field]
+
     # citekey
 
     citekey = args.citekey

--- a/pubs/commands/edit_cmd.py
+++ b/pubs/commands/edit_cmd.py
@@ -59,6 +59,12 @@ def command(conf, args):
                 ui.info(("The metadata of paper '{}' was successfully "
                          "edited.".format(color.dye_out(citekey, 'citekey'))))
             else:
+                # exclude bibtex fields if specified
+                for item in content.values():
+                    for field in conf['main']['bibtex_field_excludes']:
+                        if field in item:
+                            del item[field]
+
                 new_paper = Paper.from_bibentry(content,
                                                 metadata=paper.metadata)
                 if rp.rename_paper(new_paper, old_citekey=paper.citekey):

--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -53,6 +53,11 @@ def command(conf, args):
     for p in papers:
         bib[p.citekey] = p.bibdata
 
+        # exclude bibtex fields if specified
+        for field in conf['main']['bibtex_field_excludes']:
+            if field in bib[p.citekey]:
+                del bib[p.citekey][field]
+
     exporter = endecoder.EnDecoder()
     bibdata_raw = exporter.encode_bibdata(bib, args.ignore_fields)
     ui.message(bibdata_raw)

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -35,6 +35,9 @@ max_authors = integer(default=3)
 # the full python stack is printed.
 debug = boolean(default=False)
 
+# which bibliographic fields to exclude from bibtex files.
+bibtex_field_excludes = force_list(default=list())
+
 [formating]
 
 # Enable bold formatting, if the terminal supports it.

--- a/tests/str_fixtures.py
+++ b/tests/str_fixtures.py
@@ -138,6 +138,9 @@ edit_cmd = "vim"
 # the full python stack is printed.
 debug = False
 
+# which bibliographic fields to exclude from bibtex files.
+bibtex_field_excludes = 
+
 [formating]
 
 # Enable bold formatting, if the terminal supports it.


### PR DESCRIPTION
First of all, many thanks for creating and maintaining pubs, which helps me a lot!

This PR adds an option to exclude any BibTeX fields (e.g. `abstract` or `publisher`) in the results of pubs commands: `add`, `import`, `export`, and `edit`.

 Which fields to exclude can be customized in `.pubsrc`, for example:

```
[main]
bibtex_field_excludes = abstract, number
```

I introduced this niche option to remove abstracts from BibTeX files in pubs directory, which I'm planning to put in a public repository. I'm concerned about putting abstracts in a public repo might cause a license problem.

I'm not sure if this feature will help people, probably not many. If anyone wants this, consider to review and merge this PR. If not, feel free to close it. Thanks!
