### PR TITLE
Option to exclude bibtex fields

### DIFF
--- a/pubs/commands/add_cmd.py
+++ b/pubs/commands/add_cmd.py
@@ -116,6 +116,12 @@ def command(conf, args):
         if bibentry is None:
             ui.error('invalid bibfile {}.'.format(bibfile))
 
+    # exclude bibtex fields if specified
+    for item in bibentry.values():
+        for field in conf['main']['bibtex_field_excludes']:
+            if field in item:
+                del item[field]
+
     # citekey
 
     citekey = args.citekey

--- a/pubs/commands/add_cmd.py
+++ b/pubs/commands/add_cmd.py
@@ -117,10 +117,7 @@ def command(conf, args):
             ui.error('invalid bibfile {}.'.format(bibfile))
 
     # exclude bibtex fields if specified
-    for item in bibentry.values():
-        for field in conf['main']['bibtex_field_excludes']:
-            if field in item:
-                del item[field]
+    utils.remove_bibtex_fields(bibentry, conf['main']['bibtex_field_excludes'])
 
     # citekey
 

--- a/pubs/commands/add_cmd.py
+++ b/pubs/commands/add_cmd.py
@@ -117,7 +117,7 @@ def command(conf, args):
             ui.error('invalid bibfile {}.'.format(bibfile))
 
     # exclude bibtex fields if specified
-    utils.remove_bibtex_fields(bibentry, conf['main']['bibtex_field_excludes'])
+    utils.remove_bibtex_fields(bibentry, conf['main']['exclude_bibtex_fields'])
 
     # citekey
 

--- a/pubs/commands/edit_cmd.py
+++ b/pubs/commands/edit_cmd.py
@@ -59,6 +59,12 @@ def command(conf, args):
                 ui.info(("The metadata of paper '{}' was successfully "
                          "edited.".format(color.dye_out(citekey, 'citekey'))))
             else:
+                # exclude bibtex fields if specified
+                for item in content.values():
+                    for field in conf['main']['bibtex_field_excludes']:
+                        if field in item:
+                            del item[field]
+
                 new_paper = Paper.from_bibentry(content,
                                                 metadata=paper.metadata)
                 if rp.rename_paper(new_paper, old_citekey=paper.citekey):

--- a/pubs/commands/edit_cmd.py
+++ b/pubs/commands/edit_cmd.py
@@ -60,7 +60,7 @@ def command(conf, args):
                          "edited.".format(color.dye_out(citekey, 'citekey'))))
             else:
                 # exclude bibtex fields if specified
-                remove_bibtex_fields(content, conf['main']['bibtex_field_excludes'])
+                remove_bibtex_fields(content, conf['main']['exclude_bibtex_fields'])
 
                 new_paper = Paper.from_bibentry(content,
                                                 metadata=paper.metadata)

--- a/pubs/commands/edit_cmd.py
+++ b/pubs/commands/edit_cmd.py
@@ -6,7 +6,7 @@ from .. import color
 
 from ..uis import get_ui
 from ..endecoder import EnDecoder
-from ..utils import resolve_citekey
+from ..utils import resolve_citekey, remove_bibtex_fields
 from ..completion import CiteKeyCompletion
 from ..events import ModifyEvent
 
@@ -60,10 +60,7 @@ def command(conf, args):
                          "edited.".format(color.dye_out(citekey, 'citekey'))))
             else:
                 # exclude bibtex fields if specified
-                for item in content.values():
-                    for field in conf['main']['bibtex_field_excludes']:
-                        if field in item:
-                            del item[field]
+                remove_bibtex_fields(content, conf['main']['bibtex_field_excludes'])
 
                 new_paper = Paper.from_bibentry(content,
                                                 metadata=paper.metadata)

--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -54,7 +54,7 @@ def command(conf, args):
         bib[p.citekey] = p.bibdata
 
     # exclude bibtex fields if specified
-    remove_bibtex_fields(bib, conf['main']['bibtex_field_excludes'])
+    remove_bibtex_fields(bib, conf['main']['exclude_bibtex_fields'])
 
     exporter = endecoder.EnDecoder()
     bibdata_raw = exporter.encode_bibdata(bib, args.ignore_fields)

--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -5,7 +5,7 @@ import argparse
 from .. import repo
 from ..uis import get_ui
 from .. import endecoder
-from ..utils import resolve_citekey_list
+from ..utils import resolve_citekey_list, remove_bibtex_fields
 from ..endecoder import BIBFIELD_ORDER
 from ..completion import CiteKeyCompletion, CommaSeparatedListCompletion
 
@@ -53,10 +53,8 @@ def command(conf, args):
     for p in papers:
         bib[p.citekey] = p.bibdata
 
-        # exclude bibtex fields if specified
-        for field in conf['main']['bibtex_field_excludes']:
-            if field in bib[p.citekey]:
-                del bib[p.citekey][field]
+    # exclude bibtex fields if specified
+    remove_bibtex_fields(bib, conf['main']['bibtex_field_excludes'])
 
     exporter = endecoder.EnDecoder()
     bibdata_raw = exporter.encode_bibdata(bib, args.ignore_fields)

--- a/pubs/commands/export_cmd.py
+++ b/pubs/commands/export_cmd.py
@@ -53,6 +53,11 @@ def command(conf, args):
     for p in papers:
         bib[p.citekey] = p.bibdata
 
+        # exclude bibtex fields if specified
+        for field in conf['main']['bibtex_field_excludes']:
+            if field in bib[p.citekey]:
+                del bib[p.citekey][field]
+
     exporter = endecoder.EnDecoder()
     bibdata_raw = exporter.encode_bibdata(bib, args.ignore_fields)
     ui.message(bibdata_raw)

--- a/pubs/commands/import_cmd.py
+++ b/pubs/commands/import_cmd.py
@@ -41,7 +41,7 @@ def parser(subparsers, conf):
     return parser
 
 
-def many_from_path(ui, bibpath, bibtex_field_excludes=[], ignore=False):
+def many_from_path(ui, bibpath, exclude_bibtex_fields=[], ignore=False):
     """Extract list of papers found in bibliographic files in path.
 
     The behavior is to:
@@ -65,7 +65,7 @@ def many_from_path(ui, bibpath, bibtex_field_excludes=[], ignore=False):
         try:
             bibentry = coder.decode_bibdata(read_text_file(filepath))
             # exclude bibtex fields if specified
-            remove_bibtex_fields(bibentry, bibtex_field_excludes)
+            remove_bibtex_fields(bibentry, exclude_bibtex_fields)
             biblist.append(bibentry)
         except coder.BibDecodingError:
             error = "Could not parse bibtex at {}.".format(filepath)
@@ -105,7 +105,7 @@ def command(conf, args):
     rp = repo.Repository(conf)
     # Extract papers from bib
     papers = many_from_path(ui, bibpath,
-        bibtex_field_excludes=conf['main']['bibtex_field_excludes'],
+        exclude_bibtex_fields=conf['main']['exclude_bibtex_fields'],
         ignore=args.ignore_malformed)
     keys = args.keys or papers.keys()
     for k in keys:

--- a/pubs/commands/import_cmd.py
+++ b/pubs/commands/import_cmd.py
@@ -41,7 +41,7 @@ def parser(subparsers, conf):
     return parser
 
 
-def many_from_path(ui, bibpath, excluded_bibtex_fields=[], ignore=False):
+def many_from_path(ui, bibpath, bibtex_field_excludes=[], ignore=False):
     """Extract list of papers found in bibliographic files in path.
 
     The behavior is to:
@@ -65,7 +65,7 @@ def many_from_path(ui, bibpath, excluded_bibtex_fields=[], ignore=False):
         try:
             bibentry = coder.decode_bibdata(read_text_file(filepath))
             # exclude bibtex fields if specified
-            remove_bibtex_fields(bibentry, excluded_bibtex_fields)
+            remove_bibtex_fields(bibentry, bibtex_field_excludes)
             biblist.append(bibentry)
         except coder.BibDecodingError:
             error = "Could not parse bibtex at {}.".format(filepath)
@@ -105,7 +105,7 @@ def command(conf, args):
     rp = repo.Repository(conf)
     # Extract papers from bib
     papers = many_from_path(ui, bibpath,
-        excluded_bibtex_fields=conf['main']['bibtex_field_excludes'],
+        bibtex_field_excludes=conf['main']['bibtex_field_excludes'],
         ignore=args.ignore_malformed)
     keys = args.keys or papers.keys()
     for k in keys:

--- a/pubs/commands/import_cmd.py
+++ b/pubs/commands/import_cmd.py
@@ -11,6 +11,7 @@ from .. import content
 from ..paper import Paper
 from ..uis import get_ui
 from ..content import system_path, read_text_file
+from ..utils import remove_bibtex_fields
 from ..command_utils import add_doc_copy_arguments
 
 
@@ -40,7 +41,7 @@ def parser(subparsers, conf):
     return parser
 
 
-def many_from_path(ui, bibpath, bibfield_excludes=[], ignore=False):
+def many_from_path(ui, bibpath, excluded_bibtex_fields=[], ignore=False):
     """Extract list of papers found in bibliographic files in path.
 
     The behavior is to:
@@ -64,10 +65,7 @@ def many_from_path(ui, bibpath, bibfield_excludes=[], ignore=False):
         try:
             bibentry = coder.decode_bibdata(read_text_file(filepath))
             # exclude bibtex fields if specified
-            for item in bibentry.values():
-                for field in bibfield_excludes:
-                    if field in item:
-                        del item[field]
+            remove_bibtex_fields(bibentry, excluded_bibtex_fields)
             biblist.append(bibentry)
         except coder.BibDecodingError:
             error = "Could not parse bibtex at {}.".format(filepath)
@@ -107,7 +105,7 @@ def command(conf, args):
     rp = repo.Repository(conf)
     # Extract papers from bib
     papers = many_from_path(ui, bibpath,
-        bibfield_excludes=conf['main']['bibtex_field_excludes'],
+        excluded_bibtex_fields=conf['main']['bibtex_field_excludes'],
         ignore=args.ignore_malformed)
     keys = args.keys or papers.keys()
     for k in keys:

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -35,6 +35,9 @@ max_authors = integer(default=3)
 # the full python stack is printed.
 debug = boolean(default=False)
 
+# which bibliographic fields to exclude from bibtex files.
+bibtex_field_excludes = force_list(default=list())
+
 [formating]
 
 # Enable bold formatting, if the terminal supports it.

--- a/pubs/config/spec.py
+++ b/pubs/config/spec.py
@@ -35,8 +35,10 @@ max_authors = integer(default=3)
 # the full python stack is printed.
 debug = boolean(default=False)
 
-# which bibliographic fields to exclude from bibtex files.
-bibtex_field_excludes = force_list(default=list())
+# which bibliographic fields to exclude from bibtex files. By default, none.
+# Please note that excluding critical fields such as `title` or `author`
+# will break many commands of pubs.
+exclude_bibtex_fields = force_list(default=list())
 
 [formating]
 

--- a/pubs/utils.py
+++ b/pubs/utils.py
@@ -88,8 +88,8 @@ def standardize_doi(doi):
 
     return new_doi
 
-def remove_bibtex_fields(bibentry, excluded_bibtex_fields=[]):
+def remove_bibtex_fields(bibentry, fields):
     for item in bibentry.values():
-        for field in excluded_bibtex_fields:
+        for field in fields:
             if field in item:
                 del item[field]

--- a/pubs/utils.py
+++ b/pubs/utils.py
@@ -87,3 +87,9 @@ def standardize_doi(doi):
     new_doi = match.group(0)
 
     return new_doi
+
+def remove_bibtex_fields(bibentry, excluded_bibtex_fields=[]):
+    for item in bibentry.values():
+        for field in excluded_bibtex_fields:
+            if field in item:
+                del item[field]

--- a/tests/str_fixtures.py
+++ b/tests/str_fixtures.py
@@ -138,6 +138,9 @@ edit_cmd = "vim"
 # the full python stack is printed.
 debug = False
 
+# which bibliographic fields to exclude from bibtex files.
+bibtex_field_excludes = 
+
 [formating]
 
 # Enable bold formatting, if the terminal supports it.

--- a/tests/str_fixtures.py
+++ b/tests/str_fixtures.py
@@ -139,7 +139,7 @@ edit_cmd = "vim"
 debug = False
 
 # which bibliographic fields to exclude from bibtex files.
-bibtex_field_excludes = 
+exclude_bibtex_fields =
 
 [formating]
 

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -447,6 +447,7 @@ class TestAdd(URLContentTestCase):
             out = endecoder.EnDecoder().decode_bibdata(buf.read())
         for bib in out.values():
             self.assertFalse('abstract' in bib or 'publisher' in bib)
+            self.assertTrue('title' in bib and 'author' in bib)
 
 
 class TestList(DataCommandTestCase):
@@ -854,6 +855,7 @@ class TestUsecase(DataCommandTestCase):
             out = endecoder.EnDecoder().decode_bibdata(buf.read())
         for bib in out.values():
             self.assertFalse('author' in bib)
+            self.assertTrue('title' in bib)
 
     def test_add_aborts(self):
         with self.assertRaises(FakeSystemExit):
@@ -945,6 +947,7 @@ class TestUsecase(DataCommandTestCase):
         outs = self.execute_cmds(['pubs export Page99'])
         for bib in endecoder.EnDecoder().decode_bibdata(outs[0]).values():
             self.assertFalse('url' in bib)
+            self.assertTrue('title' in bib and 'author' in bib)
 
     def test_import(self):
         cmds = ['pubs init',
@@ -1018,6 +1021,7 @@ class TestUsecase(DataCommandTestCase):
             out = endecoder.EnDecoder().decode_bibdata(buf.read())
         for bib in out.values():
             self.assertFalse('abstract' in bib)
+            self.assertTrue('title' in bib and 'author' in bib)
 
     def test_update(self):
         cmds = ['pubs init',

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -440,7 +440,7 @@ class TestAdd(URLContentTestCase):
     def test_add_excludes_bibtex_fields(self):
         self.execute_cmds(['pubs init'])
         config = conf.load_conf()
-        config['main']['bibtex_field_excludes'] = ['abstract', 'publisher']
+        config['main']['exclude_bibtex_fields'] = ['abstract', 'publisher']
         conf.save_conf(config)
         self.execute_cmds(['pubs add data/pagerank.bib'])
         with FakeFileOpen(self.fs)(self.default_pubs_dir + '/bib/Page99.bib', 'r') as buf:
@@ -846,7 +846,7 @@ class TestUsecase(DataCommandTestCase):
                 ]
         self.execute_cmds(cmds)
         config = conf.load_conf()
-        config['main']['bibtex_field_excludes'] = ['author']
+        config['main']['exclude_bibtex_fields'] = ['author']
         conf.save_conf(config)
         cmds = [('pubs edit Page99', ['@misc{Page99, title="TTT", author="auth"}', 'n'])]
         self.execute_cmds(cmds)
@@ -940,7 +940,7 @@ class TestUsecase(DataCommandTestCase):
                 ]
         self.execute_cmds(cmds)
         config = conf.load_conf()
-        config['main']['bibtex_field_excludes'] = ['url']
+        config['main']['exclude_bibtex_fields'] = ['url']
         conf.save_conf(config)
         outs = self.execute_cmds(['pubs export Page99'])
         for bib in endecoder.EnDecoder().decode_bibdata(outs[0]).values():
@@ -1011,7 +1011,7 @@ class TestUsecase(DataCommandTestCase):
     def test_import_excludes_bibtex_field(self):
         self.execute_cmds(['pubs init'])
         config = conf.load_conf()
-        config['main']['bibtex_field_excludes'] = ['abstract']
+        config['main']['exclude_bibtex_fields'] = ['abstract']
         conf.save_conf(config)
         self.execute_cmds(['pubs import data/ Page99'])
         with FakeFileOpen(self.fs)(self.default_pubs_dir + '/bib/Page99.bib', 'r') as buf:


### PR DESCRIPTION
First of all, many thanks for creating and maintaining pubs, which helps me a lot!

This PR adds an option to exclude any BibTeX fields (e.g. `abstract` or `publisher`) in the results of pubs commands: `add`, `import`, `export`, and `edit`.

 Which fields to exclude can be customized in `.pubsrc`, for example:

```
[main]
bibtex_field_excludes = abstract, number
```

I introduced this niche option to remove abstracts from BibTeX files in pubs directory, which I'm planning to put in a public repository. I'm concerned about putting abstracts in a public repo might cause a license problem.

I'm not sure if this feature will help people, probably not many. If anyone wants this, consider to review and merge this PR. If not, feel free to close it. Thanks!
