### PR TITLE
Replaced pipes with shlex

### DIFF
--- a/pubs/plugs/alias/alias.py
+++ b/pubs/plugs/alias/alias.py
@@ -1,7 +1,7 @@
 import shlex
 import subprocess
 import argparse
-from pipes import quote as shell_quote
+from shlex import quote as shell_quote
 
 from ...plugins import PapersPlugin
 from ...pubs_cmd import execute

--- a/pubs/plugs/git/git.py
+++ b/pubs/plugs/git/git.py
@@ -2,7 +2,7 @@ import os
 import sys
 import argparse
 from subprocess import Popen, PIPE, STDOUT
-from pipes import quote as shell_quote
+from shlex import quote as shell_quote
 
 from ... import uis
 from ...plugins import PapersPlugin


### PR DESCRIPTION
Python 3.0 deprecated the pipes module and Python 3.13 removed it. The shlex module provides a drop-in replacement for the quote function from pipes that is used by pubs. This resolves [https://github.com/pubs/pubs/issues/282](https://github.com/pubs/pubs/issues/282).