### PR TITLE
Fix deprecated/invalid config in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = readme.md
+description_file = readme.md


### PR DESCRIPTION
Dash-separated keys for setuptools config have been deprecated in [v54.1.10 (2021)](https://setuptools.pypa.io/en/latest/history.html#id855)and removed in [v78](https://setuptools.pypa.io/en/latest/history.html#v78-0-0).